### PR TITLE
Extensible records

### DIFF
--- a/src/backend.ml
+++ b/src/backend.ml
@@ -82,6 +82,11 @@ module Vernac = struct
     let open Vernacexpr in
     vernac_ (VernacSynPure (VernacInductive (Inductive_kw, ind_def)))
 
+  (* The VernacInductive.t associated with this record *)
+  let define_record (rd: VernacInductive.t) : unit t =
+    let open Vernacexpr in
+    vernac_ (VernacSynPure (VernacInductive (Record, rd)))
+  
   let define_inductive_scheme
       (specs : (Names.Id.t * Names.Id.t * Sorts.family) list) : unit t =
     let open Vernacexpr in
@@ -317,7 +322,7 @@ module Vernac = struct
     let proof, _ = Declare.Proof.by interppfs proof in
     (*let opaque = Vernacexpr.Opaque in*)
     let _ = Declare.Proof.save_regular ~proof ~opaque ~idopt:None in
-    return ()
+    return ()  
 end
 
 (** "Declare Backend": Code generation backend by mutating the internal state of Coq's "contexts" *)

--- a/src/backend.mli
+++ b/src/backend.mli
@@ -11,7 +11,9 @@ module Vernac : sig
   val flatmap : 'a t list -> unit t
   val run : 'a t -> 'a
   val end_proof : Names.Id.t -> unit t
+  
   val define_inductive : VernacInductive.t -> unit t
+  val define_record : VernacInductive.t -> unit t
 
   val define_inductive_scheme :
     (Names.Id.t * Names.Id.t * Sorts.family) list -> unit t

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -838,14 +838,18 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
 
     (* Record stuff *)
     | Snoc
-       (fields, (_, RecordDefinition { original; _ })) ->
+       (fields, (_, RecordDefinition { rd; original; _ })) ->
        let open B in
        let* _ = compile_fields fields ctx in
-       B.define_record original
+       let __internal_original, _ = VernacInductive.definition_mapping original in
+       let* _ = B.define_record __internal_original in
+       let body = Constrexpr_ops.mkIdentC (Naming.internal_name rd.name) in 
+       B.define_term ~name:rd.name body       
 
     | Snoc (fields, (_, RecordConstrAxiom { name; record_name; _ })) ->
        let open B in
        let* _ = compile_fields fields ctx in
+       let record_name = Naming.internal_name record_name in
        let body = Constrexpr_ops.mkIdentC (Naming.rocq_record_constructor ~record_name) in 
        B.define_term ~name body  
 

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -664,7 +664,7 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
         names
         |> List.map (fun name -> B.define_term ~name (qualify name))
         |> flatmap
-
+    
     | Snoc (fields, (_, RecordDefinition { rd; _ } )) ->
        let open B in
        let* _ = compile_fields fields in
@@ -673,8 +673,8 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
        in 
        names
        |> List.map (fun name -> B.define_term ~name (qualify name))
-       |> flatmap
-    | Snoc (fields, (_, (RecordComputationalAxiom { name; _} | ComputationalAxiom { name; _ }))) ->
+       |> flatmap    
+    | Snoc (fields, (_, (RecordConstrAxiom { name; _ } | RecordComputationalAxiom { name; _} | ComputationalAxiom { name; _ }))) ->
         let open B in
         let* _ = compile_fields fields in
         B.define_term ~name (qualify name)
@@ -706,8 +706,7 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
         let open B in
         let* _ = compile_fields fields in
         B.define_term ~name (qualify name)
-    | Snoc (fields, (_, Marker _)) | Snoc (fields, (_, InductiveAxiom _))
-    | Snoc (fields, (_, RecordConstrAxiom _))
+    | Snoc (fields, (_, Marker _)) | Snoc (fields, (_, InductiveAxiom _))    
     | Snoc (fields, (_, RecursiveAxiom _)) -> compile_fields fields
     | Snoc (fields, (_, InductiveDefinition { inductive; _ })) ->
         let open B in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -836,7 +836,7 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
             let _ = compile_linkage (Some synth_ctx) nested_linkage in
             return ())
 
-    (* Record stuff *)
+    (* Record definition *)
     | Snoc
        (fields, (_, RecordDefinition { rd; original; _ })) ->
        let open B in
@@ -846,11 +846,24 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
        let body = Constrexpr_ops.mkIdentC (Naming.internal_name rd.name) in 
        B.define_term ~name:rd.name body       
 
-    | Snoc (fields, (_, RecordConstrAxiom { name; record_name; _ })) ->
+    (* Record constructors *)
+    | Snoc (fields, (_, RecordConstrAxiom { name; record_name; defaults; fields = record_fields; _ })) ->
+       (* The default values go after the arguments *)
        let open B in
        let* _ = compile_fields fields ctx in
-       let record_name = Naming.internal_name record_name in
-       let body = Constrexpr_ops.mkIdentC (Naming.rocq_record_constructor ~record_name) in 
+       let record_name = Naming.internal_name record_name in       
+       let parameters =
+         record_fields
+         |> List.map Names.Id.to_string
+         |> List.map (fun prefix -> Naming.fresh_name ~prefix)
+       in
+       let arguments = List.map Constrexpr_ops.mkIdentC parameters @ List.map Constrexpr_ops.mkRefC defaults in
+       let body =
+         let open Constrexpr_ops in 
+         mkAppC (mkIdentC (Naming.rocq_record_constructor ~record_name), arguments)
+       in
+       let body = Termutils.mk_lambda parameters body in 
+       (* Def X a b c = Y a b c <default-a> <default-b> <default-c> *)
        B.define_term ~name body  
 
     (* A marker has no implementation *)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -838,11 +838,10 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
 
     (* Record stuff *)
     | Snoc
-       (fields, (_, RecordDefinition { rd; _ })) ->
+       (fields, (_, RecordDefinition { original; _ })) ->
        let open B in
        let* _ = compile_fields fields ctx in
-       rd |> ignore;
-       Errors.fail ~info:"TODO"    
+       B.define_record original
     | Snoc (_fields, (_, RecordConstrAxiom _)) -> Errors.fail ~info:"TODO"
 
     (* A marker has no implementation *)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -850,17 +850,18 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
     | Snoc (fields, (_, RecordConstrAxiom { name; record_name; defaults; fields = record_fields; _ })) ->
        (* The default values go after the arguments *)
        let open B in
-       let* _ = compile_fields fields ctx in
-       let record_name = Naming.internal_name record_name in
+       let* _ = compile_fields fields ctx in       
        let parameters =
          record_fields
          |> List.map Names.Id.to_string
          |> List.map (fun prefix -> Naming.fresh_name ~prefix)
        in
-       let arguments = List.map Constrexpr_ops.mkIdentC parameters @ List.map Constrexpr_ops.mkRefC defaults in
-       let body =
-         let open Constrexpr_ops in
+       let open Constrexpr_ops in
+       let arguments = List.map mkIdentC parameters @ List.map mkRefC defaults in
+       let body =         
          let main_record_constr =
+           (* Record name is prefixed with `__internal_` because of "definition mapping" *)
+           let record_name = Naming.internal_name record_name in
            Naming.rocq_record_constructor ~record_name          
          in 
          mkAppC (mkIdentC main_record_constr, arguments)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -798,14 +798,11 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
         let open B in
         let* _ = compile_fields fields ctx in        
         compile_finduction_implementation ~recursor_names:names ~inductive_paths ~suffix ~goals ~handlers
-    | Snoc (fields, (_, ComputationalAxiom { name; axiom; _ })) ->
+    | Snoc (fields, (_, (RecordComputationalAxiom { name; axiom; _ } | ComputationalAxiom { name; axiom; _ }))) ->
         let open B in
         let* _ = compile_fields fields ctx in
         compile_computational_axiom_implementation ~axiom_name:name
-          ~axiom_expr:axiom
-
-    (* Can we reuse bare computational axioms? *)
-    | Snoc (_fields, (_, RecordComputationalAxiom _)) -> Errors.fail ~info:"TODO: fixed point of a RecordComputationalAxiom"
+          ~axiom_expr:axiom       
 
     | Snoc (fields, (name, ClosingFact { type_name; script; plain; _ })) ->
         let open B in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -862,7 +862,7 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
          let open Constrexpr_ops in 
          mkAppC (mkIdentC (Naming.rocq_record_constructor ~record_name), arguments)
        in
-       let body = Termutils.mk_lambda parameters body in 
+       let body = Termutils.mk_lambda parameters body in
        (* Def X a b c = Y a b c <default-a> <default-b> <default-c> *)
        B.define_term ~name body  
 

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -842,7 +842,12 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
        let open B in
        let* _ = compile_fields fields ctx in
        B.define_record original
-    | Snoc (_fields, (_, RecordConstrAxiom _)) -> Errors.fail ~info:"TODO"
+
+    | Snoc (fields, (_, RecordConstrAxiom { name; record_name; _ })) ->
+       let open B in
+       let* _ = compile_fields fields ctx in
+       let body = Constrexpr_ops.mkIdentC (Naming.rocq_record_constructor ~record_name) in 
+       B.define_term ~name body  
 
     (* A marker has no implementation *)
     | Snoc (fields, (_, Marker _)) -> compile_fields fields ctx

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -674,7 +674,7 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
        names
        |> List.map (fun name -> B.define_term ~name (qualify name))
        |> flatmap
-    | Snoc (fields, (_, ComputationalAxiom { name; _ })) ->
+    | Snoc (fields, (_, (RecordComputationalAxiom { name; _} | ComputationalAxiom { name; _ }))) ->
         let open B in
         let* _ = compile_fields fields in
         B.define_term ~name (qualify name)
@@ -803,6 +803,10 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
         let* _ = compile_fields fields ctx in
         compile_computational_axiom_implementation ~axiom_name:name
           ~axiom_expr:axiom
+
+    (* Can we reuse bare computational axioms? *)
+    | Snoc (_fields, (_, RecordComputationalAxiom _)) -> Errors.fail ~info:"TODO: fixed point of a RecordComputationalAxiom"
+
     | Snoc (fields, (name, ClosingFact { type_name; script; plain; _ })) ->
         let open B in
         let* _ = compile_fields fields ctx in

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -851,7 +851,7 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
        (* The default values go after the arguments *)
        let open B in
        let* _ = compile_fields fields ctx in
-       let record_name = Naming.internal_name record_name in       
+       let record_name = Naming.internal_name record_name in
        let parameters =
          record_fields
          |> List.map Names.Id.to_string
@@ -859,8 +859,11 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
        in
        let arguments = List.map Constrexpr_ops.mkIdentC parameters @ List.map Constrexpr_ops.mkRefC defaults in
        let body =
-         let open Constrexpr_ops in 
-         mkAppC (mkIdentC (Naming.rocq_record_constructor ~record_name), arguments)
+         let open Constrexpr_ops in
+         let main_record_constr =
+           Naming.rocq_record_constructor ~record_name          
+         in 
+         mkAppC (mkIdentC main_record_constr, arguments)
        in
        let body = Termutils.mk_lambda parameters body in
        (* Def X a b c = Y a b c <default-a> <default-b> <default-c> *)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -664,6 +664,16 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
         names
         |> List.map (fun name -> B.define_term ~name (qualify name))
         |> flatmap
+
+    | Snoc (fields, (_, RecordDefinition { rd; _ } )) ->
+       let open B in
+       let* _ = compile_fields fields in
+       let names =
+         rd.name ::  List.map fst rd.fields
+       in 
+       names
+       |> List.map (fun name -> B.define_term ~name (qualify name))
+       |> flatmap
     | Snoc (fields, (_, ComputationalAxiom { name; _ })) ->
         let open B in
         let* _ = compile_fields fields in
@@ -824,6 +834,14 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
             in
             let _ = compile_linkage (Some synth_ctx) nested_linkage in
             return ())
+
+    | Snoc
+       (fields, (_, RecordDefinition { rd; _ })) ->
+       let open B in
+       let* _ = compile_fields fields ctx in
+       rd |> ignore;
+       Errors.fail ~info:"TODO"
+       
     (* An implementation will be provided by the inductive *)
     | Snoc (fields, (_, InductiveAxiom _)) -> compile_fields fields ctx
     (* Implementation provided by RecursiveDefinition *)

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -706,8 +706,8 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
         let open B in
         let* _ = compile_fields fields in
         B.define_term ~name (qualify name)
-    | Snoc (fields, (_, Marker _)) -> compile_fields fields
-    | Snoc (fields, (_, InductiveAxiom _)) -> compile_fields fields
+    | Snoc (fields, (_, Marker _)) | Snoc (fields, (_, InductiveAxiom _))
+    | Snoc (fields, (_, RecordConstrAxiom _))
     | Snoc (fields, (_, RecursiveAxiom _)) -> compile_fields fields
     | Snoc (fields, (_, InductiveDefinition { inductive; _ })) ->
         let open B in
@@ -836,12 +836,14 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
             let _ = compile_linkage (Some synth_ctx) nested_linkage in
             return ())
 
+    (* Record stuff *)
     | Snoc
        (fields, (_, RecordDefinition { rd; _ })) ->
        let open B in
        let* _ = compile_fields fields ctx in
        rd |> ignore;
-       Errors.fail ~info:"TODO"
+       Errors.fail ~info:"TODO"    
+    | Snoc (_fields, (_, RecordConstrAxiom _)) -> Errors.fail ~info:"TODO"
 
     (* A marker has no implementation *)
     | Snoc (fields, (_, Marker _)) -> compile_fields fields ctx

--- a/src/codegen.ml
+++ b/src/codegen.ml
@@ -706,6 +706,7 @@ let synthesize_context ~(context : (Names.Id.t * Constrexpr.module_ast) Bwd.t)
         let open B in
         let* _ = compile_fields fields in
         B.define_term ~name (qualify name)
+    | Snoc (fields, (_, Marker _)) -> compile_fields fields
     | Snoc (fields, (_, InductiveAxiom _)) -> compile_fields fields
     | Snoc (fields, (_, RecursiveAxiom _)) -> compile_fields fields
     | Snoc (fields, (_, InductiveDefinition { inductive; _ })) ->
@@ -841,7 +842,9 @@ let rec compile_linkage (synth_ctx : synth_ctx option) (linkage : Linkage.t) =
        let* _ = compile_fields fields ctx in
        rd |> ignore;
        Errors.fail ~info:"TODO"
-       
+
+    (* A marker has no implementation *)
+    | Snoc (fields, (_, Marker _)) -> compile_fields fields ctx
     (* An implementation will be provided by the inductive *)
     | Snoc (fields, (_, InductiveAxiom _)) -> compile_fields fields ctx
     (* Implementation provided by RecursiveDefinition *)

--- a/src/entry.ml
+++ b/src/entry.ml
@@ -145,4 +145,10 @@ let open_trait_with_base_list ~name ~bases =
 let final_family = Family.define_final_family
 let add_wildcard_handler = Recursion.add_wildcard_handler
 
-let add_record = Records.add_record
+let add_record ~inductive =
+  let rd = Types.RecordDecl.parse inductive in
+  Records.add_record rd inductive
+
+let extend_record ~inductive ~defaults =
+  let rd = Types.RecordDecl.parse inductive in
+  Records.extend_record ~rd ~inductive ~defaults

--- a/src/entry.ml
+++ b/src/entry.ml
@@ -144,3 +144,5 @@ let open_trait_with_base_list ~name ~bases =
 
 let final_family = Family.define_final_family
 let add_wildcard_handler = Recursion.add_wildcard_handler
+
+let add_record = Records.add_record

--- a/src/entry.mli
+++ b/src/entry.mli
@@ -88,4 +88,4 @@ val open_trait : name:Names.Id.t -> unit
 val final_family : name:Names.Id.t -> value:Libnames.qualid -> unit
 val add_wildcard_handler : handler:Constrexpr.constr_expr -> unit
 
-val add_record : RecordDecl.t -> unit
+val add_record : RecordDecl.t -> VernacInductive.t -> unit

--- a/src/entry.mli
+++ b/src/entry.mli
@@ -88,4 +88,9 @@ val open_trait : name:Names.Id.t -> unit
 val final_family : name:Names.Id.t -> value:Libnames.qualid -> unit
 val add_wildcard_handler : handler:Constrexpr.constr_expr -> unit
 
-val add_record : RecordDecl.t -> VernacInductive.t -> unit
+val add_record : inductive:VernacInductive.t -> unit
+
+val extend_record :
+  inductive:VernacInductive.t ->
+  defaults:(Names.Id.t * Constrexpr.constr_expr) list ->
+  unit

--- a/src/entry.mli
+++ b/src/entry.mli
@@ -87,3 +87,5 @@ val open_trait_with_base_list : name:Names.Id.t -> bases:Names.Id.t list -> unit
 val open_trait : name:Names.Id.t -> unit
 val final_family : name:Names.Id.t -> value:Libnames.qualid -> unit
 val add_wildcard_handler : handler:Constrexpr.constr_expr -> unit
+
+val add_record : RecordDecl.t -> unit

--- a/src/env.ml
+++ b/src/env.ml
@@ -420,16 +420,25 @@ module Context = struct
     in
     context |> further_bound_linkage |> List.filter_map lookup
 
-  let lookup_fields ~(prefix: Libnames.qualid option) ~(names : Names.Id.t list) ~context : Names.Id.t option =    
+  let lookup_fields ~(prefix: Libnames.qualid option) ~(names : Names.Id.t list) ~context : Names.Id.t option =
+    let rec reachable_fields = function
+        | LinkageCtx.Toplevel linkage -> linkage.fields
+        | LinkageCtx.Nested (parent_ctx, linkage) ->            
+            let parent_fields = reachable_fields parent_ctx in
+            let current_fields = linkage.fields in
+            parent_fields <@ Bwd.to_list current_fields
+    in
     let linkage =
       match prefix with
-      | None -> family_linkage context
+      | None -> family_linkage context (* This is duplication *)
       | Some prefix ->
          match lookup_linkage_elem context prefix with         
          | Some (LinkageElem.FamilyDefinition {linkage; _}, _) -> linkage
-         | _ -> family_linkage context
+         | _ -> family_linkage context (* Also duplication *)
     in
-    let Linkage.{ fields; _ } = linkage in
+    let Linkage.{ fields = more_fields; _ } = linkage in
+    let fields = reachable_fields context in
+    let fields = fields <@ Bwd.to_list more_fields in 
     
     let rec find_matching_constructor fields =
       match fields with

--- a/src/env.ml
+++ b/src/env.ml
@@ -420,8 +420,15 @@ module Context = struct
     in
     context |> further_bound_linkage |> List.filter_map lookup
 
-  let lookup_fields ~(names : Names.Id.t list) ~context : Names.Id.t option =    
-    let linkage = family_linkage context in
+  let lookup_fields ~(prefix: Libnames.qualid option) ~(names : Names.Id.t list) ~context : Names.Id.t option =    
+    let linkage =
+      match prefix with
+      | None -> family_linkage context
+      | Some prefix ->
+         match lookup_linkage_elem context prefix with         
+         | Some (LinkageElem.FamilyDefinition {linkage; _}, _) -> linkage
+         | _ -> family_linkage context
+    in
     let Linkage.{ fields; _ } = linkage in
     
     let rec find_matching_constructor fields =

--- a/src/env.ml
+++ b/src/env.ml
@@ -113,7 +113,7 @@ module Linkages = struct
   let lookup name =
     match lookup_internal name with
     | None -> lookup_external name
-    | Some l -> Some l
+    | Some l -> Some l  
 end
 
 (* TODO: Give this a better name *)
@@ -419,4 +419,22 @@ module Context = struct
              if found ~bound_names then Some (inh, linkage, elem) else None)
     in
     context |> further_bound_linkage |> List.filter_map lookup
+
+  let lookup_fields ~(names : Names.Id.t list) ~context : Names.Id.t option =    
+    let linkage = family_linkage context in
+    let Linkage.{ fields; _ } = linkage in
+    
+    let rec find_matching_constructor fields =
+      match fields with
+      | Bwd.Emp -> None
+      | Bwd.Snoc (rest, (name, LinkageElem.RecordConstrAxiom { fields = constructor_fields; _ })) ->
+          if List.length constructor_fields = List.length names &&
+             List.for_all2 Names.Id.equal constructor_fields names then
+            Some name
+          else
+            find_matching_constructor rest
+      | Bwd.Snoc (rest, _) -> find_matching_constructor rest
+    in
+    
+    find_matching_constructor fields
 end

--- a/src/env.mli
+++ b/src/env.mli
@@ -59,7 +59,7 @@ module Context : sig
     field:Names.Id.t ->
     ((Names.Id.t * Names.Id.t) * Linkage.t * LinkageElem.t) list
   
-  val lookup_fields : names:Names.Id.t list -> context:LinkageCtx.t -> Names.Id.t option
+  val lookup_fields : prefix:Libnames.qualid option -> names:Names.Id.t list -> context:LinkageCtx.t -> Names.Id.t option
 
   val replace : linkage:Linkage.t -> unit
   val destructive_update : LinkageCtx.t option -> unit

--- a/src/env.mli
+++ b/src/env.mli
@@ -58,6 +58,8 @@ module Context : sig
     LinkageCtx.t ->
     field:Names.Id.t ->
     ((Names.Id.t * Names.Id.t) * Linkage.t * LinkageElem.t) list
+  
+  val lookup_fields : names:Names.Id.t list -> context:LinkageCtx.t -> Names.Id.t option
 
   val replace : linkage:Linkage.t -> unit
   val destructive_update : LinkageCtx.t option -> unit

--- a/src/ftactics.ml
+++ b/src/ftactics.ml
@@ -158,7 +158,7 @@ let fsimpl () =
       let unfolds = generate_unfolds "__funfold" case_definitions in
 
       let names =
-        computational_axioms
+        computational_axioms @ computational_axioms
         |> List.map Pretty.pretty_qualid
         |> String.concat "\n"
       in
@@ -197,15 +197,17 @@ let fsimpl_star () =
       let handlers = extract_handlers_names all_names in
 
       let computational_axioms = handlers_to_computational_axiom handlers in
+      let context = Env.Context.get () in
+      let record_computational_axioms = extract_record_computational_axioms context in
 
       let case_definitions = handlers_to_case_definitions handlers in
 
-      let rewrites = generate_rewrites computational_axioms in
+      let rewrites = generate_rewrites (computational_axioms @ record_computational_axioms) in
 
       let unfolds = generate_unfolds "__funfold_star" case_definitions in
 
       let names =
-        computational_axioms
+        computational_axioms @ record_computational_axioms
         |> List.map Pretty.pretty_qualid
         |> String.concat "\n"
       in
@@ -247,6 +249,8 @@ let fsimpl_in h =
       let handlers = extract_handlers_names hyps_names in
 
       let computational_axioms = handlers_to_computational_axiom handlers in
+      let context = Env.Context.get () in
+      let record_computational_axioms = extract_record_computational_axioms context in
 
       let case_definitions = handlers_to_case_definitions handlers in
 
@@ -269,7 +273,7 @@ let fsimpl_in h =
           Tacinterp.interp tactic
         in
         let all_rewrite_tactics =
-          List.map each_rewrite_tactic computational_axioms
+          List.map each_rewrite_tactic (computational_axioms @ record_computational_axioms)
         in
         let union_rewrites =
           List.fold_right
@@ -309,7 +313,7 @@ let fsimpl_in h =
       in
 
       let names =
-        computational_axioms
+        computational_axioms @ record_computational_axioms
         |> List.map Pretty.pretty_qualid
         |> String.concat "\n"
       in

--- a/src/ftactics.ml
+++ b/src/ftactics.ml
@@ -1,5 +1,37 @@
 (* Custom tactics for family polymorphism *)
 open Types
+open Bwd
+
+(* We want to accumulate RecordComputationalAxiom in the current family *)
+(* if we have Family we want to recursively check inside for RecordComputationalAxiom and append
+   the appropriate path prefix *)
+let extract_record_computational_axioms (ctx : LinkageCtx.t) : Libnames.qualid list =
+  let rec extract_from_linkage (linkage : Linkage.t) prefix_path =
+    linkage.fields
+    |> Bwd.to_list
+    |> List.fold_left (fun acc (name, elem) ->
+        let qualified_name = 
+          match prefix_path with
+          | [] -> Libnames.qualid_of_ident name
+          | _ -> Naming.qualid_point (Some (Naming.list_to_path prefix_path)) name
+        in
+        match elem with
+        | LinkageElem.RecordComputationalAxiom _ ->
+            qualified_name :: acc
+        | LinkageElem.FamilyDefinition { linkage = nested_linkage; _ } ->
+            let nested_axioms = extract_from_linkage nested_linkage (prefix_path @ [name]) in
+            nested_axioms @ acc
+        | _ -> acc
+      ) []
+  in
+  let rec extract_from_ctx = function
+    | LinkageCtx.Toplevel linkage -> extract_from_linkage linkage []
+    | LinkageCtx.Nested (parent_ctx, linkage) ->
+        let parent_axioms = extract_from_ctx parent_ctx in
+        let current_axioms = extract_from_linkage linkage [] in
+        parent_axioms @ current_axioms
+  in
+  extract_from_ctx ctx
 
 (* selfnames -> (function, handler list) *)
 let extract_handlers_names names =
@@ -116,10 +148,12 @@ let fsimpl () =
       let handlers = extract_handlers_names goal_names in
 
       let computational_axioms = handlers_to_computational_axiom handlers in
+      let context = Env.Context.get () in
+      let record_computational_axioms = extract_record_computational_axioms context in
 
       let case_definitions = handlers_to_case_definitions handlers in
 
-      let rewrites = generate_rewrites computational_axioms in
+      let rewrites = generate_rewrites (computational_axioms @ record_computational_axioms) in
 
       let unfolds = generate_unfolds "__funfold" case_definitions in
 

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -46,15 +46,16 @@ DECLARE PLUGIN "rocqet.plugin"
 }
 
 GRAMMAR EXTEND Gram
-GLOBAL: mutind_defs llconstr_ip gallina_ext list1ident reference_ip;
+GLOBAL: mutind_defs llconstr_ip gallina_ext list1ident reference_ip ;
   list1ident :
     [[ listid = LIST1 ident -> { listid }]];  
   mutind_defs :
     [[ indl = LIST1 inductive_or_record_definition SEP "with" -> { indl } ]];
   llconstr_ip :
-    [[ c = lconstr -> { (* attach_self_prefix *) c } ]];
+    [[ c = lconstr -> { c } ]];
   reference_ip :
-    [[ r = reference -> { (* attach_self_prefix_qualid*) r } ]];
+    [[ r = reference -> { r } ]];    
+  
   gallina_ext : TOP
     [[  ]];
 END

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -52,7 +52,7 @@ GLOBAL: mutind_defs llconstr_ip gallina_ext list1ident reference_ip ;
   mutind_defs :
     [[ indl = LIST1 inductive_or_record_definition SEP "with" -> { indl } ]];
   llconstr_ip :
-    [[ c = lconstr -> { c } ]];
+    [[ c = lconstr -> { Records.resolve_record_constr c } ]];
   reference_ip :
     [[ r = reference -> { r } ]];    
   
@@ -181,7 +181,7 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
    { Entry.closing_fact ~name ~ty ~script ~plain:true }
 
 | [ "FHint" reference_ip(inductive) ident(left) ident(right) ] -> 
-  { failwith "" }
+  { Errors.fail ~info:"FHint: not yet implemented" }
 
 (*| [ "Prect" reference_ip(inductive_path) ] -> { 
     Partial_recursor.add ~inductive_path

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -97,6 +97,8 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
+| [ "FRecord" mutind_defs(record_definition) ] -> { () }
+
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 
 | [ "Trait" ident(name) "extends"

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -97,7 +97,10 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
-| [ "FRecord" mutind_defs(record_definition) ] -> { Types.RecordDecl.parse record_definition }
+| [ "FRecord" mutind_defs(record_definition) ] -> {
+    let rd = Types.RecordDecl.parse record_definition in
+    Entry.add_record rd
+  }
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -97,7 +97,7 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
-| [ "FRecord" mutind_defs(record_definition) ] -> { () }
+| [ "FRecord" mutind_defs(record_definition) ] -> { Types.RecordDecl.parse record_definition }
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -91,8 +91,8 @@ ARGUMENT EXTEND record_default
   | [ ident(n) ":=" llconstr_ip(e) ] -> { (n, e) }
 END
 
-ARGUMENT EXTEND record_default_list
-  | [ record_default(arg) "," record_default_list(rest) ] -> { arg :: rest }
+ARGUMENT EXTEND record_defaults
+  | [ record_default(arg) "," record_defaults(rest) ] -> { arg :: rest }
   | [ record_default(d) ] -> { [ d ] }  
 END
 
@@ -106,7 +106,7 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
-| [ "FRecord" mutind_defs(record_definition) "default" record_default_list(defaults) ] -> { () }
+| [ "FRecord" mutind_defs(record_definition) "default" record_defaults(defaults) ] -> { () }
 
 | [ "FRecord" mutind_defs(record_definition) ] -> {
     let rd = Types.RecordDecl.parse record_definition in

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -97,10 +97,16 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
+| [ "FRecord" mutind_defs(record_definition)
+      "with"
+      "default"
+      ident(name) ":=" llconstr_ip(body_expr) ] ->
+   { Errors.fail ~info:"TODO: "}
 | [ "FRecord" mutind_defs(record_definition) ] -> {
     let rd = Types.RecordDecl.parse record_definition in
     Entry.add_record rd record_definition
   }
+
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -99,7 +99,7 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FRecord" mutind_defs(record_definition) ] -> {
     let rd = Types.RecordDecl.parse record_definition in
-    Entry.add_record rd
+    Entry.add_record rd record_definition
   }
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -87,6 +87,15 @@ VERNAC ARGUMENT EXTEND argument_flist
   | [ argument(arg) "->" argument_flist(rest) ] -> { arg :: rest }
 END
 
+ARGUMENT EXTEND record_default
+  | [ ident(n) ":=" llconstr_ip(e) ] -> { (n, e) }
+END
+
+ARGUMENT EXTEND record_default_list
+  | [ record_default(arg) "," record_default_list(rest) ] -> { arg :: rest }
+  | [ record_default(d) ] -> { [ d ] }  
+END
+
 VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 | [ "Family" ident(derived) "extends"
     reference_list_sep(arguments, ",") ] -> { Entry.family_extends_list ~derived ~bases:arguments }
@@ -97,16 +106,12 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
-| [ "FRecord" mutind_defs(record_definition)
-      "with"
-      "default"
-      ident(name) ":=" llconstr_ip(body_expr) ] ->
-   { Errors.fail ~info:"TODO: "}
+| [ "FRecord" mutind_defs(record_definition) "default" record_default_list(defaults) ] -> { () }
+
 | [ "FRecord" mutind_defs(record_definition) ] -> {
     let rd = Types.RecordDecl.parse record_definition in
     Entry.add_record rd record_definition
   }
-
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 

--- a/src/grammar.mlg
+++ b/src/grammar.mlg
@@ -106,12 +106,10 @@ VERNAC COMMAND EXTEND FamilyPolyExtension CLASSIFIED AS SIDEFF
 
 | [ "FInductive" mutind_defs(inductive_definition) ] -> { Entry.finductive inductive_definition }
 
-| [ "FRecord" mutind_defs(record_definition) "default" record_defaults(defaults) ] -> { () }
-
-| [ "FRecord" mutind_defs(record_definition) ] -> {
-    let rd = Types.RecordDecl.parse record_definition in
-    Entry.add_record rd record_definition
-  }
+(* Record extension *)
+| [ "FRecord" mutind_defs(inductive) "default" record_defaults(defaults) ] -> { Entry.extend_record ~inductive ~defaults }
+(* Record definition *)
+| [ "FRecord" mutind_defs(inductive) ] -> { Entry.add_record ~inductive }
 
 (* | [ "Trait" ident(name) "extends" ident(base) ] -> { Entry.open_trait_with_base ~name ~base }*)
 

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -649,6 +649,8 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
               Given our previous filtering? *)   
            let defaults = axiom.defaults @ defaults in           
            (RecordConstrAxiom { axiom with compiled_context; defaults; }, [])
+
+        | RecordComputationalAxiom _comp -> Errors.fail ~info:"TODO: inheriting a RecordComputationalAxiom"
         
         (* Exhaustiveness checks *)
         | RecursorDefinition recursive ->

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -592,9 +592,31 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
         | TraitDefinition trait ->
             let compiled_context, _ = compile_context trait.compiled_context in
             (TraitDefinition { trait with compiled_context }, [])
+
         | ComputationalAxiom comp ->
             let compiled_context, _ = compile_context comp.compiled_context in
             (ComputationalAxiom { comp with compiled_context }, [])
+
+        | RecordComputationalAxiom comp ->
+           let record_name = comp.record_name in
+           let lhs_constructor_name = comp.constructor_name in
+           let lhs_fields = comp.fields in
+           let record_name = Libnames.qualid_of_ident comp.record_name in
+           let elem =
+             match Context.lookup_linkage_elem context record_name with
+             | None -> Errors.fail ~info:(Printf.sprintf "inherit_one: Record definition not found: %s" (Names.Id.to_string comp.record_name))
+             | Some (elem, _) -> elem
+           in
+           let rhs_defaults, rhs_constructor_name, rhs_fields =
+             match elem with
+             | LinkageElem.RecordDefinition { rd; defaults; constructor_name;  _ } ->                
+                List.map snd defaults, constructor_name, List.map fst rd.fields
+             | _ -> Errors.fail ~info:(Printf.sprintf "inherit_one: Expected RecordDefinition but found different element type for: %s" (Names.Id.to_string comp.record_name))
+           in
+           let new_axioms = [] in
+           let compiled_context, _ = compile_context comp.compiled_context in
+           (RecordComputationalAxiom { comp with compiled_context }, new_axioms)
+       
         | InductiveAxiom axiom ->
             let compiled_context, _ = compile_context axiom.compiled_context in
             (InductiveAxiom { axiom with compiled_context }, [])
@@ -648,9 +670,7 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
            (* Is it always the case that axiom.defaults and defaults don't overlap?
               Given our previous filtering? *)   
            let defaults = axiom.defaults @ defaults in           
-           (RecordConstrAxiom { axiom with compiled_context; defaults; }, [])
-
-        | RecordComputationalAxiom _comp -> Errors.fail ~info:"TODO: inheriting a RecordComputationalAxiom"
+           (RecordConstrAxiom { axiom with compiled_context; defaults; }, [])        
         
         (* Exhaustiveness checks *)
         | RecursorDefinition recursive ->

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -641,11 +641,16 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
            let axiom = Resolver.resolve_constrexpr ~context ~expression:new_axiom_expr in
            let axiom_name = Naming.fresh_name ~prefix:"RecordConstructorEq" in
            let compiled_context, new_parameters =
-             compile_context comp.compiled_context
-           in
+              Context.with_unpinned_context (fun () ->
+                  compile_context comp.compiled_context)
+            in
            let compiled_signature =
              Codegen.compile_inductive_axiom ~name:axiom_name ~ty:axiom ~ctx:new_parameters
            in
+           let default_ctx_params =
+              context |> Context.family_linkage |> function
+              | { default_ctx_params; _ } -> default_ctx_params
+            in
            let new_axiom_elem =
              LinkageElem.ComputationalAxiom {
                name = axiom_name;
@@ -655,7 +660,7 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
                default_ctx_params;
              }
            in
-           let new_axioms = [new_axiom_elem] in
+           let new_axioms = [(axiom_name, new_axiom_elem)] in
            let compiled_context, _ = compile_context comp.compiled_context in
            (RecordComputationalAxiom { comp with compiled_context }, new_axioms)
        

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -585,10 +585,13 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
             (MetaDataSection { metadata with compiled_context }, [])
         | OpaqueFieldDefinition field ->
             let compiled_context, _ = compile_context field.compiled_context in
-            (OpaqueFieldDefinition { field with compiled_context }, [])
+            (OpaqueFieldDefinition { field with compiled_context }, [])        
         | ClosingFact fact ->
             let compiled_context, _ = compile_context fact.compiled_context in
             (ClosingFact { fact with compiled_context }, [])
+        | Marker m ->
+            let compiled_context, _ = compile_context m.compiled_context in
+            (Marker { m with compiled_context }, [])
         (* Exhaustiveness checks *)
         | RecursorDefinition recursive ->
             let inductive, _, _ =

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -597,21 +597,24 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
             let compiled_context, _ = compile_context comp.compiled_context in
             (ComputationalAxiom { comp with compiled_context }, [])
 
-        | RecordComputationalAxiom comp ->
-           let record_name = comp.record_name in
-           let lhs_constructor_name = comp.constructor_name in
-           let lhs_fields = comp.fields in
-           let record_name = Libnames.qualid_of_ident record_name in
+        | RecordComputationalAxiom ({ kind = RecordCompAxiomKind.RecordConstrEq; _ } as comp) ->
+           let compiled_context, _ = compile_context comp.compiled_context in
+           (RecordComputationalAxiom { comp with compiled_context }, [])
+
+        | RecordComputationalAxiom ({ kind = RecordCompAxiomKind.RecordFieldComp { record_name; constructor_name; fields }; _ } as comp) ->
+           let lhs_constructor_name = constructor_name in
+           let lhs_fields = fields in
+           let record_name_qualid = Libnames.qualid_of_ident record_name in
            let elem =
-             match Context.lookup_linkage_elem context record_name with
-             | None -> Errors.fail ~info:(Printf.sprintf "inherit_one: Record definition not found: %s" (Names.Id.to_string comp.record_name))
+             match Context.lookup_linkage_elem context record_name_qualid with
+             | None -> Errors.fail ~info:(Printf.sprintf "inherit_one: Record definition not found: %s" (Names.Id.to_string record_name))
              | Some (elem, _) -> elem
            in
            let rhs_defaults, rhs_constructor_name, rhs_fields =
              match elem with
              | LinkageElem.RecordDefinition { rd; defaults; constructor_name;  _ } ->                
                 defaults, constructor_name, List.map fst rd.fields
-             | _ -> Errors.fail ~info:(Printf.sprintf "inherit_one: Expected RecordDefinition but found different element type for: %s" (Names.Id.to_string comp.record_name))
+             | _ -> Errors.fail ~info:(Printf.sprintf "inherit_one: Expected RecordDefinition but found different element type for: %s" (Names.Id.to_string record_name))
            in
            let new_axiom_expr =
              let open Constrexpr_ops in
@@ -651,13 +654,14 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
               context |> Context.family_linkage |> function
               | { default_ctx_params; _ } -> default_ctx_params
             in
-           let new_axiom_elem =
-             LinkageElem.ComputationalAxiom {
-               name = axiom_name;
-               axiom;                                             
-               compiled_context;
-               compiled_signature;
-               default_ctx_params;
+           let new_axiom_elem =             
+             LinkageElem.RecordComputationalAxiom {
+              name = axiom_name;
+              kind = RecordCompAxiomKind.RecordConstrEq;
+              axiom;                                             
+              compiled_context;
+              compiled_signature;
+              default_ctx_params;
              }
            in
            let new_axioms = [(axiom_name, new_axiom_elem)] in

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -190,7 +190,7 @@ and linkage_elem_concatenate ~name ~(derived : LinkageElem.t)
       in
       TraitDefinition { derived with linkage }
 
-  | RecordDefinition _, RecordDefinition _ -> Errors.fail ~info:"TODO"
+  | RecordDefinition _, RecordDefinition _ -> Errors.fail ~info:"TODO: how do we do record linkage concatenation?"
 
   (* TODO: remove this wildcard pattern *)
   | _, _ ->
@@ -618,8 +618,38 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
         | Marker m ->
             let compiled_context, _ = compile_context m.compiled_context in
             (Marker { m with compiled_context }, [])
-        | RecordConstrAxiom _ ->           
-           Errors.fail ~info:"TODO: what happens when we inherit a record constructor?"
+
+        | RecordDefinition rd ->           
+           let compiled_context, _ = compile_context rd.compiled_context in
+           (RecordDefinition { rd with compiled_context }, [])
+        | RecordConstrAxiom axiom ->
+           (* 1. Fetch the record definition
+              hopefully the record definition will have: 
+              (a) The fields required by this constructor axiom 
+              (b) The names of default values we want *)
+           let record_name = Libnames.qualid_of_ident axiom.record_name in 
+           let elem =
+             match Context.lookup_linkage_elem context record_name with
+             | None -> Errors.fail ~info:(Printf.sprintf "inherit_one: Record definition not found: %s" (Names.Id.to_string axiom.record_name))
+             | Some (elem, _) -> elem
+           in
+           let defaults =
+             match elem with
+             | LinkageElem.RecordDefinition { defaults; _ } ->
+                (* Only the names that does *not* already exist in our defaults list *)
+                defaults 
+                |> List.map snd 
+                |> List.filter (fun x -> not (List.exists ((=) x) axiom.defaults))
+             | _ -> Errors.fail ~info:(Printf.sprintf "inherit_one: Expected RecordDefinition but found different element type for: %s" (Names.Id.to_string axiom.record_name))
+           in
+           let compiled_context, _ =
+              compile_context axiom.compiled_context
+           in
+           (* Is it always the case that axiom.defaults and defaults don't overlap?
+              Given our previous filtering? *)   
+           let defaults = axiom.defaults @ defaults in
+           (RecordConstrAxiom { axiom with compiled_context; defaults; }, [])
+        
         (* Exhaustiveness checks *)
         | RecursorDefinition recursive ->
             let inductive, _, _ =
@@ -651,9 +681,7 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
             let compiled_context, _ =
               compile_context theorem.compiled_context
             in
-            (TheoremDefinition { theorem with goals = theorem.goals; compiled_context }, [])
-        | RecordDefinition _rd ->           
-           Errors.fail ~info:"TODO"
+            (TheoremDefinition { theorem with goals = theorem.goals; compiled_context }, [])        
       in
       let open Bwd.Infix in
       let fields = Snoc (linkage.fields, (name, element)) <@ fresh_elements in

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -592,6 +592,8 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
         | Marker m ->
             let compiled_context, _ = compile_context m.compiled_context in
             (Marker { m with compiled_context }, [])
+        | RecordConstrAxiom _ ->           
+           Errors.fail ~info:"TODO: what happens when we inherit a record constructor?"
         (* Exhaustiveness checks *)
         | RecursorDefinition recursive ->
             let inductive, _, _ =

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -601,7 +601,7 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
            let record_name = comp.record_name in
            let lhs_constructor_name = comp.constructor_name in
            let lhs_fields = comp.fields in
-           let record_name = Libnames.qualid_of_ident comp.record_name in
+           let record_name = Libnames.qualid_of_ident record_name in
            let elem =
              match Context.lookup_linkage_elem context record_name with
              | None -> Errors.fail ~info:(Printf.sprintf "inherit_one: Record definition not found: %s" (Names.Id.to_string comp.record_name))
@@ -610,10 +610,52 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
            let rhs_defaults, rhs_constructor_name, rhs_fields =
              match elem with
              | LinkageElem.RecordDefinition { rd; defaults; constructor_name;  _ } ->                
-                List.map snd defaults, constructor_name, List.map fst rd.fields
+                defaults, constructor_name, List.map fst rd.fields
              | _ -> Errors.fail ~info:(Printf.sprintf "inherit_one: Expected RecordDefinition but found different element type for: %s" (Names.Id.to_string comp.record_name))
            in
-           let new_axioms = [] in
+           let new_axiom_expr =
+             let open Constrexpr_ops in
+             let field_name_to_argument =
+               lhs_fields
+               |> List.map (fun name -> (name, Naming.fresh_name ~prefix:(Names.Id.to_string name)))
+             in  
+             let lhs_arguments = field_name_to_argument |> List.map snd |> List.map mkIdentC in                          
+             let lhs_args_for_rhs = 
+               rhs_fields
+               |> List.map (fun rhs_field ->
+                  match List.assoc_opt rhs_field field_name_to_argument with
+                  | Some arg -> mkIdentC arg 
+                  | None ->                    
+                     match List.assoc_opt rhs_field rhs_defaults with
+                     | Some default_value -> mkRefC default_value
+                     | None -> Errors.fail ~info:("inherit_one -- No default value found for field: " ^ Names.Id.to_string rhs_field))
+             in
+             
+             let lhs_constructor = mkAppC (mkIdentC lhs_constructor_name, lhs_arguments) in
+             let rhs_constructor = mkAppC (mkIdentC rhs_constructor_name, lhs_args_for_rhs) in
+             let eq_cstr = mkIdentC @@ Names.Id.of_string "eq" in
+             let eq_cstr_applied = mkAppC (eq_cstr, [ lhs_constructor; rhs_constructor ]) in  
+             Termutils.lambda_to_prod @@
+               Termutils.mk_lambda (List.map snd field_name_to_argument) eq_cstr_applied
+           in           
+           let axiom = Resolver.resolve_constrexpr ~context ~expression:new_axiom_expr in
+           let axiom_name = Naming.fresh_name ~prefix:"RecordConstructorEq" in
+           let compiled_context, new_parameters =
+             compile_context comp.compiled_context
+           in
+           let compiled_signature =
+             Codegen.compile_inductive_axiom ~name:axiom_name ~ty:axiom ~ctx:new_parameters
+           in
+           let new_axiom_elem =
+             LinkageElem.ComputationalAxiom {
+               name = axiom_name;
+               axiom;                                             
+               compiled_context;
+               compiled_signature;
+               default_ctx_params;
+             }
+           in
+           let new_axioms = [new_axiom_elem] in
            let compiled_context, _ = compile_context comp.compiled_context in
            (RecordComputationalAxiom { comp with compiled_context }, new_axioms)
        

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -620,7 +620,9 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
             let compiled_context, _ =
               compile_context theorem.compiled_context
             in
-            (TheoremDefinition { theorem with goals = theorem.goals; compiled_context }, [])                        
+            (TheoremDefinition { theorem with goals = theorem.goals; compiled_context }, [])
+        | RecordDefinition _rd ->           
+           Errors.fail ~info:"TODO"
       in
       let open Bwd.Infix in
       let fields = Snoc (linkage.fields, (name, element)) <@ fresh_elements in

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -7,6 +7,28 @@ open Bwd
 let lookup_field_in_base ~field ~context =
   Context.base_linkage_elem context ~field |> Option.map snd
 
+(*
+On Linkage Concatenation and Provenance
+  
+One of the most important components of this file is Linkage Concatenation. Linkage
+Contatenation is a technique that *allows* us to modularly compose linkages as the
+name might hint at. Without taking a closer look, this technique might seem
+striaghtforward to implement. However, there are a few considerations one has to
+take into account for this to work correctly. One of such consideration is
+about how to answer the question: what should be done about duplicate linkage
+elements when contatenating two linkages?
+A simple, and perhaps practical, solution to this problem is to 
+arbitrarily pick one of the duplicate linkage elements and drop the other.
+This is not totally correct, but it is not also wrong; that is, some times
+picking arbitrarily gives us the correct semantics, but other times, we
+get the wrong semantics. We usually want the former when
+the duplication arises from linkage elements or sub-element (e.g inductive
+constructors) that have *equal* provenance; this is, this linkage element
+can be traced to *one* family, and it is present in two (or more) families
+because it has been passed down via an inheritance ancestry. If this is not
+the case, it should be an error.
+*)
+
 let rec linkage_concatenate ~(derived : Linkage.t) ~(base : Linkage.t) =
   let rec find_and_remove name fields =
     match fields with

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -647,7 +647,7 @@ let rec inherit_one ~(name : Names.Id.t) ~(element : LinkageElem.t)
            in
            (* Is it always the case that axiom.defaults and defaults don't overlap?
               Given our previous filtering? *)   
-           let defaults = axiom.defaults @ defaults in
+           let defaults = axiom.defaults @ defaults in           
            (RecordConstrAxiom { axiom with compiled_context; defaults; }, [])
         
         (* Exhaustiveness checks *)

--- a/src/inheritance.ml
+++ b/src/inheritance.ml
@@ -189,6 +189,10 @@ and linkage_elem_concatenate ~name ~(derived : LinkageElem.t)
         linkage_concatenate ~derived:derived.linkage ~base:base.linkage
       in
       TraitDefinition { derived with linkage }
+
+  | RecordDefinition _, RecordDefinition _ -> Errors.fail ~info:"TODO"
+
+  (* TODO: remove this wildcard pattern *)
   | _, _ ->
       let info =
         Printf.sprintf

--- a/src/naming.ml
+++ b/src/naming.ml
@@ -23,8 +23,8 @@ let fresh_name ~prefix =
 
 let rocqet_record_constructor ~record_name ~family_name =  
   let prefix = Printf.sprintf "Build_%s_%s" (Names.Id.to_string record_name) (Names.Id.to_string family_name) in
-  (* fresh_name ~prefix *)
-  prefix |> Names.Id.of_string
+  fresh_name ~prefix
+  (* prefix |> Names.Id.of_string*)
 
 let rocq_record_constructor ~record_name =
   let prefix = Printf.sprintf "Build_%s" (Names.Id.to_string record_name) in

--- a/src/naming.ml
+++ b/src/naming.ml
@@ -21,9 +21,13 @@ let fresh_name ~prefix =
   let time_stamp = string_of_int @@ unique_id () in
   Names.Id.of_string (prefix ^ "回" ^ current_module ^ "_" ^ time_stamp)
 
-let record_constructor ~record_name ~family_name =  
+let rocqet_record_constructor ~record_name ~family_name =  
   let prefix = Printf.sprintf "Build_%s_%s" (Names.Id.to_string record_name) (Names.Id.to_string family_name) in
   (* fresh_name ~prefix *)
+  prefix |> Names.Id.of_string
+
+let rocq_record_constructor ~record_name =
+  let prefix = Printf.sprintf "Build_%s" (Names.Id.to_string record_name) in
   prefix |> Names.Id.of_string
 
 (* Magic constants embedded in these functions *)

--- a/src/naming.ml
+++ b/src/naming.ml
@@ -1,6 +1,30 @@
 (* Some of these functions are copied verbatim from
    https://github.com/DKXXXL/FPOP/blob/main/src/utils.ml#L407*)
 
+let unique_id =
+  let counter = Summary.ref ~name:"FreshCounter" 0 in
+  fun () ->
+    incr counter;
+    !counter
+
+let get_current_module () =
+  let remove_dots str =
+    Str.global_replace (Str.regexp "\\.") "" str
+  in
+  let mp = Lib.current_mp () in
+  (* remove the dots becuase they will lead to invalid IDs, but
+   qualified modules have the dot *)
+  mp |> Names.ModPath.to_string |> remove_dots
+
+let fresh_name ~prefix =
+  let current_module = get_current_module () in 
+  let time_stamp = string_of_int @@ unique_id () in
+  Names.Id.of_string (prefix ^ "回" ^ current_module ^ "_" ^ time_stamp)
+
+let record_constructor ~record_name ~family_name =  
+  let prefix = Printf.sprintf "Build_%s_%s" (Names.Id.to_string record_name) (Names.Id.to_string family_name) in
+  fresh_name ~prefix
+
 (* Magic constants embedded in these functions *)
 let motive_of name = Nameops.add_prefix "__motiveT" name
 let internal_name name = Nameops.add_prefix "__internal_" name
@@ -283,26 +307,6 @@ let add_prefix_path ~(path : Libnames.qualid) ~(names : Names.Id.Set.t)
     | cn -> map_constr_expr_with_binders Names.Id.Set.remove go names cn
   in
   go names target
-
-let get_current_module () =
-  let remove_dots str =
-    Str.global_replace (Str.regexp "\\.") "" str
-  in
-  let mp = Lib.current_mp () in
-  (* remove the dots becuase they will lead to invalid IDs, but
-   qualified modules have the dot *)
-  mp |> Names.ModPath.to_string |> remove_dots
-
-let unique_id =
-  let counter = Summary.ref ~name:"FreshCounter" 0 in
-  fun () ->
-    incr counter;
-    !counter
-
-let fresh_name ~prefix =
-  let current_module = get_current_module () in 
-  let time_stamp = string_of_int @@ unique_id () in
-  Names.Id.of_string (prefix ^ "回" ^ current_module ^ "_" ^ time_stamp)
 
 let module_name_of ~family_name type_name =
   let prefix =

--- a/src/naming.ml
+++ b/src/naming.ml
@@ -23,7 +23,8 @@ let fresh_name ~prefix =
 
 let record_constructor ~record_name ~family_name =  
   let prefix = Printf.sprintf "Build_%s_%s" (Names.Id.to_string record_name) (Names.Id.to_string family_name) in
-  fresh_name ~prefix
+  (* fresh_name ~prefix *)
+  prefix |> Names.Id.of_string
 
 (* Magic constants embedded in these functions *)
 let motive_of name = Nameops.add_prefix "__motiveT" name

--- a/src/naming.mli
+++ b/src/naming.mli
@@ -4,7 +4,8 @@ val recursor_type : inductive:Names.Id.t -> string -> Names.Id.t
 val handler_type : Names.Id.t -> suffix:string -> Names.Id.t
 val inductive_axiom_name : Names.Id.t -> Names.Id.t
 val recursive_axiom_name : Names.Id.t -> Names.Id.t
-val record_constructor : record_name:Names.Id.t -> family_name:Names.Id.t -> Names.Id.t
+val rocqet_record_constructor : record_name:Names.Id.t -> family_name:Names.Id.t -> Names.Id.t
+val rocq_record_constructor : record_name:Names.Id.t ->  Names.Id.t
 
 val recursion_handler_type :
   function_name:Names.Id.t -> case_name:Names.Id.t -> Names.Id.t

--- a/src/naming.mli
+++ b/src/naming.mli
@@ -4,6 +4,7 @@ val recursor_type : inductive:Names.Id.t -> string -> Names.Id.t
 val handler_type : Names.Id.t -> suffix:string -> Names.Id.t
 val inductive_axiom_name : Names.Id.t -> Names.Id.t
 val recursive_axiom_name : Names.Id.t -> Names.Id.t
+val record_constructor : record_name:Names.Id.t -> family_name:Names.Id.t -> Names.Id.t
 
 val recursion_handler_type :
   function_name:Names.Id.t -> case_name:Names.Id.t -> Names.Id.t

--- a/src/records.ml
+++ b/src/records.ml
@@ -58,6 +58,7 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
         name = constructor_name;
         record_name = name;
         fields = fields |> List.map fst;
+        defaults = [];
         compiled_context;
         compiled_signature;
         default_ctx_params

--- a/src/records.ml
+++ b/src/records.ml
@@ -122,13 +122,12 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
          let compiled_signature =
            Codegen.compile_inductive_axiom ~name ~ty:axiom ~ctx:parameters
          in
+         let kind = RecordCompAxiomKind.RecordFieldComp { record_name; constructor_name; fields = field_names; } in
          let elem =
            LinkageElem.RecordComputationalAxiom {
                name;
                axiom;               
-               record_name;
-               constructor_name;
-               fields = field_names;
+               kind;               
                compiled_context;
                compiled_signature;
                default_ctx_params

--- a/src/records.ml
+++ b/src/records.ml
@@ -132,19 +132,27 @@ let extend_record
 
 let resolve_record_constr (expr : Constrexpr.constr_expr) =
   let context = Context.get () in
-  let expr_no_loc = expr.v in
-  (* TODO: This should be a fold to ensure we deeply resolve it *)
-  match expr_no_loc with
-  | Constrexpr.CRecord fields ->
-     let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in
-     let exprs = List.map snd fields in 
-     let record_constructor =
-       match Context.lookup_fields ~names:args ~context with
-       | None ->
-          (* We can either error out or just return the expression, untouched, back to Rocq *)
-          Errors.fail ~info:"Cannot find a suitable constructor for record literal"
-       | Some n -> n 
-     in
-     let open Constrexpr_ops in
-     mkAppC (mkIdentC record_constructor, exprs)
-  | _ -> expr
+  
+  let resolve_one_level () (expr: Constrexpr.constr_expr) =
+    let expr_no_loc = expr.v in
+    match expr_no_loc with
+    | Constrexpr.CRecord fields ->
+        let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in
+        let exprs = List.map snd fields in 
+        let record_constructor =
+          match Context.lookup_fields ~names:args ~context with
+          | None ->
+             (* We can either error out or just return the expression, untouched, back to Rocq *)
+             Errors.fail ~info:"Cannot find a suitable constructor for record literal"
+          | Some n -> n 
+        in
+        let open Constrexpr_ops in
+        mkAppC (mkIdentC record_constructor, exprs)
+    | _ -> expr
+  in
+  let expr = resolve_one_level () expr in  
+  Constrexpr_ops.map_constr_expr_with_binders
+    (fun _ _ -> ())
+    resolve_one_level
+    ()
+    expr

--- a/src/records.ml
+++ b/src/records.ml
@@ -24,6 +24,7 @@ let add_record rd =
 
   
   (* The record constructor *)
+  let context = Context.get () in
   let family_name = Context.family_name context in
   let constructor_name = Naming.record_constructor ~record_name:name ~family_name in
   let args_type = fields |> List.map snd in
@@ -31,8 +32,11 @@ let add_record rd =
     let expression = Constrexpr_ops.mkIdentC name in
     Resolver.resolve_constrexpr ~context ~expression
   in 
-  let constructor_type = Termutils.mk_arrow_ty ~args_type ~ret_type in 
-  let context = Context.get () in
+  let constructor_type =
+    Termutils.mk_arrow_ty ~args_type ~ret_type
+  in
+  (* Resolve it *)
+  let constructor_type = Resolver.resolve_constrexpr ~context ~expression:constructor_type in   
   let compiled_context, parameters =
     Codegen.compile_linkage_context ~field_name:name context
   in

--- a/src/records.ml
+++ b/src/records.ml
@@ -136,7 +136,9 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
   let resolve_one_level () (expr: Constrexpr.constr_expr) =
     let expr_no_loc = expr.v in
     match expr_no_loc with
-    | Constrexpr.CProj (false, (_field_qualid, None), [], _record_expr) -> Errors.fail ~info:"We know how to interpret"
+    | Constrexpr.CProj (false, (field_qualid, None), [], record_expr) ->
+       let open Constrexpr_ops in
+       mkAppC (mkRefC field_qualid, [record_expr])
     | Constrexpr.CProj _ -> Errors.fail ~info:"Unable to interpret the projection expression"
     | Constrexpr.CRecord fields ->
         let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in

--- a/src/records.ml
+++ b/src/records.ml
@@ -131,16 +131,16 @@ let extend_record
   
   add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults
 
-
 let resolve_record_constr (expr : Constrexpr.constr_expr) =
   let context = Context.get () in
   
-  let resolve_one_level () (expr: Constrexpr.constr_expr) =
-    let expr_no_loc = expr.v in
-    match expr_no_loc with
+  let rec transform_expr (expr: Constrexpr.constr_expr) =
+    let loc = expr.CAst.loc in
+    let open Constrexpr in
+    match expr.CAst.v with
     | Constrexpr.CProj (false, (field_qualid, None), [], record_expr) ->
        let open Constrexpr_ops in
-       mkAppC (mkRefC field_qualid, [record_expr])
+       mkAppC (mkRefC field_qualid, [transform_expr record_expr])
     | Constrexpr.CProj _ -> Errors.fail ~info:"Unable to interpret the projection expression"
     | Constrexpr.CRecord fields ->
        let prefix =
@@ -151,7 +151,7 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
             if List.is_empty p then None else Some (Naming.list_to_path p)
        in
        let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in        
-       let exprs = List.map snd fields in 
+       let exprs = List.map (fun (_, e) -> transform_expr e) fields in 
        let record_constructor =
          match Context.lookup_fields ~prefix ~names:args ~context with
          | None ->
@@ -162,11 +162,51 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
        let record_constructor = Naming.qualid_point prefix record_constructor in
        let open Constrexpr_ops in
        mkAppC (mkRefC record_constructor, exprs)
-    | _ -> expr
+    (* Leaf nodes - no recursion needed *)
+    | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ -> 
+       expr
+    | CApp (f, args) ->
+       CAst.make ?loc (CApp (transform_expr f, List.map (fun (e, expl) -> (transform_expr e, expl)) args))
+    | CAppExpl (f, args) ->
+       CAst.make ?loc (CAppExpl (f, List.map transform_expr args))
+    | CProdN (bl, e) ->
+       CAst.make ?loc (CProdN (bl, transform_expr e))
+    | CLambdaN (bl, e) ->
+       CAst.make ?loc (CLambdaN (bl, transform_expr e))
+    | CLetIn (name, e1, ty, e2) ->
+       CAst.make ?loc (CLetIn (name, transform_expr e1, Option.map transform_expr ty, transform_expr e2))
+    | CCases (style, rtn, cases, branches) ->
+       let rtn' = Option.map transform_expr rtn in
+       let cases' = List.map (fun (e, name, pat) -> (transform_expr e, name, pat)) cases in
+       CAst.make ?loc (CCases (style, rtn', cases', branches))
+    | CLetTuple (names, rtn, e1, e2) ->
+       CAst.make ?loc (CLetTuple (names, (fst rtn, Option.map transform_expr (snd rtn)), transform_expr e1, transform_expr e2))
+    | CIf (c, rtn, e1, e2) ->
+       CAst.make ?loc (CIf (transform_expr c, (fst rtn, Option.map transform_expr (snd rtn)), transform_expr e1, transform_expr e2))
+    | CFix (id, fixes) ->
+       let fixes' = List.map (fun (id, order, bl, ty, body) -> 
+         (id, order, bl, transform_expr ty, transform_expr body)) fixes in
+       CAst.make ?loc (CFix (id, fixes'))
+    | CCoFix (id, cofixes) ->
+       let cofixes' = List.map (fun (id, bl, ty, body) -> 
+         (id, bl, transform_expr ty, transform_expr body)) cofixes in
+       CAst.make ?loc (CCoFix (id, cofixes'))
+    | CCast (e0, cty, e1) ->       
+       CAst.make ?loc (CCast (transform_expr e0, cty, transform_expr e1))
+    
+    | CGeneralization (kind, e) ->
+       CAst.make ?loc (CGeneralization (kind, transform_expr e))
+    | CDelimiters (scope, b, e) ->
+       CAst.make ?loc (CDelimiters (scope, b, transform_expr e))
+    | CNotation (scope_opt, notation, (constrs, constr_lists, binders, binder_lists)) ->
+       let constrs' = List.map transform_expr constrs in
+       let constr_lists' = List.map (List.map transform_expr) constr_lists in       
+       CAst.make ?loc (CNotation (scope_opt, notation, (constrs', constr_lists', binders, binder_lists)))       
+    | CArray (u, tys, def, ty) ->
+       let tys' = Array.map transform_expr tys in
+       let def' = transform_expr def in
+       let ty' = transform_expr ty in
+       CAst.make ?loc (CArray (u, tys', def', ty'))
   in
-  let expr = resolve_one_level () expr in  
-  Constrexpr_ops.map_constr_expr_with_binders
-    (fun _ _ -> ())
-    resolve_one_level
-    ()
-    expr
+  transform_expr expr
+    

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,5 +1,5 @@
 open Types
-open Env 
+open Env
 
 let add_record rd original_inductive =
   let context = Context.get () in
@@ -80,6 +80,11 @@ let add_record rd original_inductive =
          let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
          Context.add_field ~name:n ~elem
        )
-  
-  
-
+    
+let extend_record
+      ~(rd: RecordDecl.t)
+      ~(original_inductive: VernacInductive.t)
+      ~(defaults: (Names.Id.t * Constrexpr.constr_expr) list) =
+  rd |> ignore ; 
+  original_inductive |> ignore ;
+  defaults |> ignore

--- a/src/records.ml
+++ b/src/records.ml
@@ -136,6 +136,8 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
   let resolve_one_level () (expr: Constrexpr.constr_expr) =
     let expr_no_loc = expr.v in
     match expr_no_loc with
+    | Constrexpr.CProj (false, (_field_qualid, None), [], _record_expr) -> Errors.fail ~info:"We know how to interpret"
+    | Constrexpr.CProj _ -> Errors.fail ~info:"Unable to interpret the projection expression"
     | Constrexpr.CRecord fields ->
         let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in
         let exprs = List.map snd fields in 

--- a/src/records.ml
+++ b/src/records.ml
@@ -19,12 +19,15 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
   let compiled_signature =
     Codegen.compile_inductive_axiom ~name ~ty ~ctx:parameters
   in
+  let family_name = Context.family_name context in
+  let constructor_name = Naming.rocqet_record_constructor ~record_name:name ~family_name in
   let elem =
     LinkageElem.RecordDefinition
       {
         rd;
         original = inductive;
         defaults;
+        constructor_name;
         compiled_context;
         compiled_signature;
         default_ctx_params;        
@@ -34,9 +37,7 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
 
   
   (* The *introduction* form *)
-  let context = Context.get () in
-  let family_name = Context.family_name context in
-  let constructor_name = Naming.rocqet_record_constructor ~record_name:name ~family_name in
+  let context = Context.get () in  
   let args_type = fields |> List.map snd in
   let record_type =
     let expression = Constrexpr_ops.mkIdentC name in
@@ -59,6 +60,7 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
         record_name = name;
         fields = fields |> List.map fst;
         defaults = [];
+        main_constr_name = None;
         compiled_context;
         compiled_signature;
         default_ctx_params

--- a/src/records.ml
+++ b/src/records.ml
@@ -128,4 +128,3 @@ let extend_record
   in
   
   add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults
-  

--- a/src/records.ml
+++ b/src/records.ml
@@ -214,10 +214,7 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
        in
        let record_constructor = Naming.qualid_point prefix record_constructor in
        let open Constrexpr_ops in
-       mkAppC (mkRefC record_constructor, exprs)
-    (* Leaf nodes - no recursion needed *)
-    | CHole _ | CGenarg _ | CGenargGlob _ | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ -> 
-       expr
+       mkAppC (mkRefC record_constructor, exprs)        
     | CApp (f, args) ->
        CAst.make ?loc (CApp (transform_expr f, List.map (fun (e, expl) -> (transform_expr e, expl)) args))
     | CAppExpl (f, args) ->
@@ -260,6 +257,10 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
        let def' = transform_expr def in
        let ty' = transform_expr ty in
        CAst.make ?loc (CArray (u, tys', def', ty'))
+
+    (* Base cases *)
+    | CHole _ | CGenarg _ | CGenargGlob _
+    | CEvar _ | CPatVar _ | CSort _ | CPrim _ | CRef _ -> expr
   in
   transform_expr expr
     

--- a/src/records.ml
+++ b/src/records.ml
@@ -87,7 +87,7 @@ let add_record rd inductive =
     
 let extend_record
       ~(rd: RecordDecl.t)
-      ~(original_inductive: VernacInductive.t)
+      ~(inductive: VernacInductive.t)
       ~(defaults: (Names.Id.t * Constrexpr.constr_expr) list) =
 
   (* 1. Lookup the name in the base context *)
@@ -105,7 +105,7 @@ let extend_record
   in  
   
   (* 3. Concatenate VernacInductive.t relative to record definition *)
-  let new_inductive = VernacInductive.concatenate ~base:base_inductive ~derived:original_inductive in
+  let new_inductive = VernacInductive.concatenate ~base:base_inductive ~derived:inductive in
   
   (* 4. Concatenate the RecordDecl.t *)
   let new_rd = RecordDecl.{ base_rd with fields = base_rd.fields @ fields } in

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,7 +1,7 @@
 open Types
 open Env
 
-let add_record rd original_inductive =
+let add_record_with_defaults ~rd ~inductive ~defaults =
   let context = Context.get () in
   let rd = Resolver.resolve_record ~context ~rd in
   let RecordDecl.{ name; ty; fields } = rd in  
@@ -23,10 +23,11 @@ let add_record rd original_inductive =
     LinkageElem.RecordDefinition
       {
         rd;
+        original = inductive;
+        defaults;
         compiled_context;
         compiled_signature;
-        default_ctx_params;
-        original = original_inductive;
+        default_ctx_params;        
       }
   in  
   Context.add_field ~name ~elem;
@@ -80,30 +81,49 @@ let add_record rd original_inductive =
          let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
          Context.add_field ~name:n ~elem
        )
+
+let add_record rd inductive =
+  add_record_with_defaults ~rd ~inductive ~defaults:[]
     
 let extend_record
       ~(rd: RecordDecl.t)
       ~(original_inductive: VernacInductive.t)
       ~(defaults: (Names.Id.t * Constrexpr.constr_expr) list) =
 
-
   (* 1. Lookup the name in the base context *)
   let context = Context.get () in
-  let RecordDecl.{ name; _ } = rd in
+  let rd = Resolver.resolve_record ~context ~rd in 
+  let RecordDecl.{ name; fields; _ } = rd in
   let base_elem = Inheritance.lookup_field_in_base ~field:name ~context in
   
   (* 2. Ensure the linkage element we extract is a RecordDefinition *)
-  let base_rd, base_original_inductive = 
+  let base_rd, base_inductive = 
     match base_elem with
     | None -> Errors.fail ~info:"No base record definition found to extend"
     | Some (LinkageElem.RecordDefinition br) -> (br.rd, br.original)
     | Some _ -> Errors.fail ~info:"Base element is not a RecordDefinition"
+  in  
+  
+  (* 3. Concatenate VernacInductive.t relative to record definition *)
+  let new_inductive = VernacInductive.concatenate ~base:base_inductive ~derived:original_inductive in
+  
+  (* 4. Concatenate the RecordDecl.t *)
+  let new_rd = RecordDecl.{ base_rd with fields = base_rd.fields @ fields } in
+    
+  (* 5.  Keep track of default values *)
+  let defaults =
+    defaults
+    |> List.map (fun (name, value) ->
+        let internal_name_ident = Naming.fresh_name ~prefix:(Names.Id.to_string name) in           
+        let internal_name = Libnames.qualid_of_ident internal_name_ident in
+        let body_type =
+          match List.assoc_opt name rd.fields with
+          | None -> Errors.fail ~info:(Printf.sprintf "unbound field: %s" (Names.Id.to_string name))
+          | Some ty -> ty 
+        in           
+        Definition.add_definition ~name:internal_name_ident ~body_type value ;            
+        (name, internal_name))
   in
   
-  (* Concatenate VernacInductive.t relative to record definition *)
-  (* Concatenate the RecordDecl.t *)
-  (* Keep track of default values *)
-
-  (* What does this mean for the implementation of this record? *)
-
-  ()
+  add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults
+  

--- a/src/records.ml
+++ b/src/records.ml
@@ -105,8 +105,28 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
            Codegen.compile_inductive_axiom ~name:n ~ty:t ~ctx:parameters
          in
          let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
-         Context.add_field ~name:n ~elem
+         Context.add_field ~name:n ~elem);
+
+  (* The computational behvaiour *)
+  let field_names = fields |> List.map fst in
+  fields
+  |> List.iter (fun (field_name, _) ->
+         let context = Context.get () in
+         let expression = construct_one_field_comp_axiom ~field_name ~constructor_name ~field_names in
+         let axiom = Resolver.resolve_constrexpr ~context ~expression in
+         let name = Naming.fresh_name ~prefix:"RecordCompAxiom" in
+         let compiled_context, parameters =
+           Codegen.compile_linkage_context ~field_name:name context
+         in
+         let compiled_signature =
+           Codegen.compile_inductive_axiom ~name ~ty:axiom ~ctx:parameters
+         in
+         let elem = LinkageElem.RecordComputationalAxiom { name; axiom; compiled_context; compiled_signature; default_ctx_params } in
+         Context.add_field ~name ~elem
        )
+    
+
+
 
 let add_record rd inductive =
   add_record_with_defaults ~rd ~inductive ~defaults:[]

--- a/src/records.ml
+++ b/src/records.ml
@@ -35,7 +35,7 @@ let add_record rd original_inductive =
   (* The *introduction* form *)
   let context = Context.get () in
   let family_name = Context.family_name context in
-  let constructor_name = Naming.record_constructor ~record_name:name ~family_name in
+  let constructor_name = Naming.rocqet_record_constructor ~record_name:name ~family_name in
   let args_type = fields |> List.map snd in
   let record_type =
     let expression = Constrexpr_ops.mkIdentC name in

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,0 +1,3 @@
+
+let add_record _rd = ()
+

--- a/src/records.ml
+++ b/src/records.ml
@@ -23,17 +23,17 @@ let add_record rd =
   Context.add_field ~name ~elem;
 
   
-  (* The record constructor *)
+  (* The *introduction* form *)
   let context = Context.get () in
   let family_name = Context.family_name context in
   let constructor_name = Naming.record_constructor ~record_name:name ~family_name in
   let args_type = fields |> List.map snd in
-  let ret_type =
+  let record_type =
     let expression = Constrexpr_ops.mkIdentC name in
     Resolver.resolve_constrexpr ~context ~expression
   in 
   let constructor_type =
-    Termutils.mk_arrow_ty ~args_type ~ret_type
+    Termutils.mk_arrow_ty ~args_type ~ret_type:record_type
   in
   (* Resolve it *)
   let constructor_type = Resolver.resolve_constrexpr ~context ~expression:constructor_type in   
@@ -54,6 +54,23 @@ let add_record rd =
     }
   in
   
-  Context.add_field ~name:constructor_name ~elem
+  Context.add_field ~name:constructor_name ~elem;
+
+  (* The *elimination* forms *)     
+  fields
+  |> List.map (fun (field_name, field_type) ->
+         field_name, Termutils.mk_arrow_ty ~args_type:[record_type] ~ret_type:field_type)
+  |> List.iter (fun (n, t) ->
+         let context = Context.get () in
+         let compiled_context, parameters =
+           Codegen.compile_linkage_context ~field_name:n context
+         in
+         let compiled_signature =
+           Codegen.compile_inductive_axiom ~name:n ~ty:t ~ctx:parameters
+         in
+         let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
+         Context.add_field ~name:n ~elem
+       )
+  
   
 

--- a/src/records.ml
+++ b/src/records.ml
@@ -4,7 +4,7 @@ open Env
 let add_record rd =
   let context = Context.get () in
   let rd = Resolver.resolve_record ~context ~rd in
-  let RecordDecl.{ name; ty; _ } = rd in  
+  let RecordDecl.{ name; ty; fields } = rd in  
   Inheritance.inherit_dependencies ~prefix:name;    
   let default_ctx_params =
     context |> Context.family_linkage |> function
@@ -16,8 +16,23 @@ let add_record rd =
   let ty = Resolver.resolve_constrexpr ~context ~expression:ty in
   let compiled_signature =
     Codegen.compile_inductive_axiom ~name ~ty ~ctx:parameters
-  in  
+  in
   let elem = LinkageElem.RecordDefinition { rd; compiled_context; compiled_signature; default_ctx_params } in  
-  Context.add_field ~name ~elem
+  Context.add_field ~name ~elem;
+  (* record constructor *)
+  
+  let family_name = Context.family_name context in
+  let constructor_name = Naming.record_constructor ~record_name:name ~family_name in
+  let args_type = fields |> List.map snd in
+  let ret_type =
+    let expression = Constrexpr_ops.mkIdentC name in
+    Resolver.resolve_constrexpr ~context ~expression
+  in 
+  let constructor_type = Termutils.mk_arrow_ty ~args_type ~ret_type in 
+  let context = Context.get () in
+  let compiled_context, parameters =
+    Codegen.compile_linkage_context ~field_name:name context
+  in
+  ()
   
 

--- a/src/records.ml
+++ b/src/records.ml
@@ -107,7 +107,7 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
          let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
          Context.add_field ~name:n ~elem);
 
-  (* The computational behvaiour *)
+  (* The *computational behaviour* *)
   let field_names = fields |> List.map fst in
   fields
   |> List.iter (fun (field_name, _) ->

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,7 +1,7 @@
 open Types
 open Env 
 
-let add_record rd =
+let add_record rd original_inductive =
   let context = Context.get () in
   let rd = Resolver.resolve_record ~context ~rd in
   let RecordDecl.{ name; ty; fields } = rd in  
@@ -19,7 +19,16 @@ let add_record rd =
   let compiled_signature =
     Codegen.compile_inductive_axiom ~name ~ty ~ctx:parameters
   in
-  let elem = LinkageElem.RecordDefinition { rd; compiled_context; compiled_signature; default_ctx_params } in  
+  let elem =
+    LinkageElem.RecordDefinition
+      {
+        rd;
+        compiled_context;
+        compiled_signature;
+        default_ctx_params;
+        original = original_inductive;
+      }
+  in  
   Context.add_field ~name ~elem;
 
   

--- a/src/records.ml
+++ b/src/records.ml
@@ -10,6 +10,8 @@ let add_record rd =
     context |> Context.family_linkage |> function
     | { default_ctx_params; _ } -> default_ctx_params
   in
+
+  (* The record type *)
   let compiled_context, parameters =
     Codegen.compile_linkage_context ~field_name:name context
   in
@@ -19,8 +21,9 @@ let add_record rd =
   in
   let elem = LinkageElem.RecordDefinition { rd; compiled_context; compiled_signature; default_ctx_params } in  
   Context.add_field ~name ~elem;
-  (* record constructor *)
+
   
+  (* The record constructor *)
   let family_name = Context.family_name context in
   let constructor_name = Naming.record_constructor ~record_name:name ~family_name in
   let args_type = fields |> List.map snd in
@@ -33,6 +36,20 @@ let add_record rd =
   let compiled_context, parameters =
     Codegen.compile_linkage_context ~field_name:name context
   in
-  ()
+  let compiled_signature =
+    Codegen.compile_inductive_axiom ~name:constructor_name ~ty:constructor_type ~ctx:parameters
+  in
+  let elem =
+    LinkageElem.RecordConstrAxiom {
+        name = constructor_name;
+        record_name = name;
+        fields = fields |> List.map fst;
+        compiled_context;
+        compiled_signature;
+        default_ctx_params
+    }
+  in
+  
+  Context.add_field ~name:constructor_name ~elem
   
 

--- a/src/records.ml
+++ b/src/records.ml
@@ -143,17 +143,25 @@ let resolve_record_constr (expr : Constrexpr.constr_expr) =
        mkAppC (mkRefC field_qualid, [record_expr])
     | Constrexpr.CProj _ -> Errors.fail ~info:"Unable to interpret the projection expression"
     | Constrexpr.CRecord fields ->
-        let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in
-        let exprs = List.map snd fields in 
-        let record_constructor =
-          match Context.lookup_fields ~names:args ~context with
-          | None ->
-             (* We can either error out or just return the expression, untouched, back to Rocq *)
-             Errors.fail ~info:"Cannot find a suitable constructor for record literal"
-          | Some n -> n 
-        in
-        let open Constrexpr_ops in
-        mkAppC (mkIdentC record_constructor, exprs)
+       let prefix =
+         match fields with
+         | [] -> None
+         | (prefix, _) :: _ ->
+            let p = prefix |> Naming.path_to_list |> List.rev |> List.tl |> List.rev in
+            if List.is_empty p then None else Some (Naming.list_to_path p)
+       in
+       let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in        
+       let exprs = List.map snd fields in 
+       let record_constructor =
+         match Context.lookup_fields ~prefix ~names:args ~context with
+         | None ->
+            (* We can either error out or just return the expression, untouched, back to Rocq *)
+            Errors.fail ~info:"Cannot find a suitable constructor for record literal"
+         | Some n -> n 
+       in
+       let record_constructor = Naming.qualid_point prefix record_constructor in
+       let open Constrexpr_ops in
+       mkAppC (mkRefC record_constructor, exprs)
     | _ -> expr
   in
   let expr = resolve_one_level () expr in  

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,3 +1,23 @@
+open Types
+open Env 
 
-let add_record _rd = ()
+let add_record rd =
+  let context = Context.get () in
+  let rd = Resolver.resolve_record ~context ~rd in
+  let RecordDecl.{ name; ty; _ } = rd in  
+  Inheritance.inherit_dependencies ~prefix:name;    
+  let default_ctx_params =
+    context |> Context.family_linkage |> function
+    | { default_ctx_params; _ } -> default_ctx_params
+  in
+  let compiled_context, parameters =
+    Codegen.compile_linkage_context ~field_name:name context
+  in
+  let ty = Resolver.resolve_constrexpr ~context ~expression:ty in
+  let compiled_signature =
+    Codegen.compile_inductive_axiom ~name ~ty ~ctx:parameters
+  in  
+  let elem = LinkageElem.RecordDefinition { rd; compiled_context; compiled_signature; default_ctx_params } in  
+  Context.add_field ~name ~elem
+  
 

--- a/src/records.ml
+++ b/src/records.ml
@@ -93,50 +93,54 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
   
   Context.add_field ~name:constructor_name ~elem;
 
-  (* The *elimination* forms *)     
-  fields
-  |> List.map (fun (field_name, field_type) ->
-         field_name, Termutils.mk_arrow_ty ~args_type:[record_type] ~ret_type:field_type)
-  |> List.iter (fun (n, t) ->
-         let context = Context.get () in
-         let compiled_context, parameters =
-           Codegen.compile_linkage_context ~field_name:n context
-         in
-         let compiled_signature =
-           Codegen.compile_inductive_axiom ~name:n ~ty:t ~ctx:parameters
-         in
-         let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
-         Context.add_field ~name:n ~elem);
+  (* The *elimination* forms *)
+  let define_elimination_forms () = 
+    fields
+    |> List.map (fun (field_name, field_type) ->
+           field_name, Termutils.mk_arrow_ty ~args_type:[record_type] ~ret_type:field_type)
+    |> List.iter (fun (n, t) ->
+           let context = Context.get () in
+           let compiled_context, parameters =
+             Codegen.compile_linkage_context ~field_name:n context
+           in
+           let compiled_signature =
+             Codegen.compile_inductive_axiom ~name:n ~ty:t ~ctx:parameters
+           in
+           let elem = LinkageElem.InductiveAxiom { compiled_context; compiled_signature; default_ctx_params } in
+           Context.add_field ~name:n ~elem)
+  in  
 
-  (* The *computational behaviour* *)
-  let field_names = fields |> List.map fst in
-  fields
-  |> List.iter (fun (field_name, _) ->
-         let context = Context.get () in
-         let expression = construct_one_field_comp_axiom ~field_name ~constructor_name ~field_names in
-         let axiom = Resolver.resolve_constrexpr ~context ~expression in
-         let name = Naming.fresh_name ~prefix:"RecordCompAxiom" in
-         let compiled_context, parameters =
-           Codegen.compile_linkage_context ~field_name:name context
-         in
-         let compiled_signature =
-           Codegen.compile_inductive_axiom ~name ~ty:axiom ~ctx:parameters
-         in
-         let kind = RecordCompAxiomKind.RecordFieldComp { record_name; constructor_name; fields = field_names; } in
-         let elem =
-           LinkageElem.RecordComputationalAxiom {
-               name;
-               axiom;               
-               kind;               
-               compiled_context;
-               compiled_signature;
-               default_ctx_params
-             }
-         in
-         Context.add_field ~name ~elem)
-    
-
-
+  (* The *computational behaviours* *)
+  let define_computational_behaviours () = 
+    let field_names = fields |> List.map fst in    
+    fields
+    |> List.iter (fun (field_name, _) ->
+           let context = Context.get () in
+           let expression = construct_one_field_comp_axiom ~field_name ~constructor_name ~field_names in
+           let axiom = Resolver.resolve_constrexpr ~context ~expression in
+           let name = Naming.fresh_name ~prefix:"RecordCompAxiom" in
+           let compiled_context, parameters =
+             Codegen.compile_linkage_context ~field_name:name context
+           in
+           let compiled_signature =
+             Codegen.compile_inductive_axiom ~name ~ty:axiom ~ctx:parameters
+           in
+           let kind = RecordCompAxiomKind.RecordFieldComp { record_name; constructor_name; fields = field_names; } in
+           let elem =
+             LinkageElem.RecordComputationalAxiom {
+                 name;
+                 axiom;               
+                 kind;               
+                 compiled_context;
+                 compiled_signature;
+                 default_ctx_params
+               }
+           in
+           Context.add_field ~name ~elem)
+  in
+  
+  Context.with_pinned_context define_elimination_forms;
+  Context.with_pinned_context define_computational_behaviours 
 
 let add_record rd inductive =
   add_record_with_defaults ~rd ~inductive ~defaults:[]

--- a/src/records.ml
+++ b/src/records.ml
@@ -128,3 +128,23 @@ let extend_record
   in
   
   add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults
+
+
+let resolve_record_constr (expr : Constrexpr.constr_expr) =
+  let context = Context.get () in
+  let expr_no_loc = expr.v in
+  (* TODO: This should be a fold to ensure we deeply resolve it *)
+  match expr_no_loc with
+  | Constrexpr.CRecord fields ->
+     let args = List.map (fun (n, _) -> Naming.extract_path_base n) fields in
+     let exprs = List.map snd fields in 
+     let record_constructor =
+       match Context.lookup_fields ~names:args ~context with
+       | None ->
+          (* We can either error out or just return the expression, untouched, back to Rocq *)
+          Errors.fail ~info:"Cannot find a suitable constructor for record literal"
+       | Some n -> n 
+     in
+     let open Constrexpr_ops in
+     mkAppC (mkIdentC record_constructor, exprs)
+  | _ -> expr

--- a/src/records.ml
+++ b/src/records.ml
@@ -85,6 +85,25 @@ let extend_record
       ~(rd: RecordDecl.t)
       ~(original_inductive: VernacInductive.t)
       ~(defaults: (Names.Id.t * Constrexpr.constr_expr) list) =
-  rd |> ignore ; 
-  original_inductive |> ignore ;
-  defaults |> ignore
+
+
+  (* 1. Lookup the name in the base context *)
+  let context = Context.get () in
+  let RecordDecl.{ name; _ } = rd in
+  let base_elem = Inheritance.lookup_field_in_base ~field:name ~context in
+  
+  (* 2. Ensure the linkage element we extract is a RecordDefinition *)
+  let base_rd, base_original_inductive = 
+    match base_elem with
+    | None -> Errors.fail ~info:"No base record definition found to extend"
+    | Some (LinkageElem.RecordDefinition br) -> (br.rd, br.original)
+    | Some _ -> Errors.fail ~info:"Base element is not a RecordDefinition"
+  in
+  
+  (* Concatenate VernacInductive.t relative to record definition *)
+  (* Concatenate the RecordDecl.t *)
+  (* Keep track of default values *)
+
+  (* What does this mean for the implementation of this record? *)
+
+  ()

--- a/src/records.ml
+++ b/src/records.ml
@@ -1,6 +1,29 @@
 open Types
 open Env
 
+(* Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x *)
+let construct_one_field_comp_axiom
+      ~(field_name: Names.Id.t)
+      ~(constructor_name: Names.Id.t)
+      ~(field_names: Names.Id.t list) =
+  let open Constrexpr_ops in
+  let field_name_to_argument =
+    field_names
+    |> List.map (fun name -> (name, Naming.fresh_name ~prefix:(Names.Id.to_string name)))
+  in  
+  let arguments = field_name_to_argument |> List.map snd |> List.map mkIdentC in
+  (* x *)
+  let right_hand_side = field_name_to_argument |> List.assoc field_name |> mkIdentC in
+  (* id (Build_lambda_arg_STLC x) *)
+  let left_hand_side =    
+    let constructor_applied = mkAppC (mkIdentC constructor_name, arguments) in
+    mkAppC (mkIdentC field_name, [constructor_applied])
+  in
+  let eq_cstr = mkIdentC @@ Names.Id.of_string "eq" in
+  let eq_cstr_applied = mkAppC (eq_cstr, [ left_hand_side; right_hand_side ]) in  
+  Termutils.lambda_to_prod @@
+    Termutils.mk_lambda (List.map snd field_name_to_argument) eq_cstr_applied 
+
 let add_record_with_defaults ~rd ~inductive ~defaults =
   let context = Context.get () in
   let rd = Resolver.resolve_record ~context ~rd in

--- a/src/records.ml
+++ b/src/records.ml
@@ -27,7 +27,8 @@ let construct_one_field_comp_axiom
 let add_record_with_defaults ~rd ~inductive ~defaults =
   let context = Context.get () in
   let rd = Resolver.resolve_record ~context ~rd in
-  let RecordDecl.{ name; ty; fields } = rd in  
+  let RecordDecl.{ name; ty; fields } = rd in
+  let record_name = name in 
   Inheritance.inherit_dependencies ~prefix:name;    
   let default_ctx_params =
     context |> Context.family_linkage |> function
@@ -121,9 +122,19 @@ let add_record_with_defaults ~rd ~inductive ~defaults =
          let compiled_signature =
            Codegen.compile_inductive_axiom ~name ~ty:axiom ~ctx:parameters
          in
-         let elem = LinkageElem.RecordComputationalAxiom { name; axiom; compiled_context; compiled_signature; default_ctx_params } in
-         Context.add_field ~name ~elem
-       )
+         let elem =
+           LinkageElem.RecordComputationalAxiom {
+               name;
+               axiom;               
+               record_name;
+               constructor_name;
+               fields = field_names;
+               compiled_context;
+               compiled_signature;
+               default_ctx_params
+             }
+         in
+         Context.add_field ~name ~elem)
     
 
 
@@ -172,7 +183,7 @@ let extend_record
         (name, internal_name))
   in
   
-  add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults
+  add_record_with_defaults ~rd:new_rd ~inductive:new_inductive ~defaults 
 
 let resolve_record_constr (expr : Constrexpr.constr_expr) =
   let context = Context.get () in

--- a/src/records.ml
+++ b/src/records.ml
@@ -92,8 +92,9 @@ let extend_record
 
   (* 1. Lookup the name in the base context *)
   let context = Context.get () in
-  let rd = Resolver.resolve_record ~context ~rd in 
+  let rd = Resolver.resolve_record ~context ~rd in  
   let RecordDecl.{ name; fields; _ } = rd in
+  Inheritance.inherit_dependencies ~prefix:name;
   let base_elem = Inheritance.lookup_field_in_base ~field:name ~context in
   
   (* 2. Ensure the linkage element we extract is a RecordDefinition *)

--- a/src/records.mli
+++ b/src/records.mli
@@ -1,0 +1,3 @@
+open Types
+
+val add_record : RecordDecl.t -> unit

--- a/src/records.mli
+++ b/src/records.mli
@@ -1,3 +1,9 @@
 open Types
 
 val add_record : RecordDecl.t -> VernacInductive.t -> unit
+
+val extend_record :
+  rd:RecordDecl.t ->
+  original_inductive:VernacInductive.t ->
+  defaults:(Names.Id.t * Constrexpr.constr_expr) list ->
+  unit

--- a/src/records.mli
+++ b/src/records.mli
@@ -1,3 +1,3 @@
 open Types
 
-val add_record : RecordDecl.t -> unit
+val add_record : RecordDecl.t -> VernacInductive.t -> unit

--- a/src/records.mli
+++ b/src/records.mli
@@ -4,6 +4,6 @@ val add_record : RecordDecl.t -> VernacInductive.t -> unit
 
 val extend_record :
   rd:RecordDecl.t ->
-  original_inductive:VernacInductive.t ->
+  inductive:VernacInductive.t ->
   defaults:(Names.Id.t * Constrexpr.constr_expr) list ->
   unit

--- a/src/records.mli
+++ b/src/records.mli
@@ -7,3 +7,5 @@ val extend_record :
   inductive:VernacInductive.t ->
   defaults:(Names.Id.t * Constrexpr.constr_expr) list ->
   unit
+
+val resolve_record_constr : Constrexpr.constr_expr -> Constrexpr.constr_expr

--- a/src/resolver.ml
+++ b/src/resolver.ml
@@ -128,3 +128,10 @@ let resolve_inductive ~context ~inductive =
     (u, paramty, tyty, cstrty)
   in
   List.map (fun (a, b) -> (resolve_constructor a, b)) inductive
+
+
+let resolve_record ~context ~rd =
+  let RecordDecl.{ name; ty; fields } = rd in
+  let ty = resolve_constrexpr ~context ~expression:ty in
+  let fields = fields |> List.map (fun (name, expression) -> (name, resolve_constrexpr ~context ~expression)) in
+  RecordDecl.{ name; ty; fields }

--- a/src/resolver.mli
+++ b/src/resolver.mli
@@ -16,6 +16,9 @@ val resolve_constrexpr_list :
 val resolve_inductive :
   context:LinkageCtx.t -> inductive:VernacInductive.t -> VernacInductive.t
 
+val resolve_record :
+  context:LinkageCtx.t -> rd:RecordDecl.t -> RecordDecl.t
+
 (* The linkage will be resolved by construction, otherwise how did it
    get created? *)
 (* val resolve_linkage : context:LinkageCtx.t -> linkage:Linkage.t ->

--- a/src/termutils.ml
+++ b/src/termutils.ml
@@ -463,6 +463,20 @@ let rec lambda_to_prod (trm : Constrexpr.constr_expr) =
       Constrexpr_ops.mkProdCN binder (lambda_to_prod body)
   | _ -> trm
 
+let mk_arrow_ty ~args_type ~ret_type =
+  let f (ty : Constrexpr.constr_expr) =
+    Constrexpr.CLocalAssum
+      ( [ CAst.make @@ Names.Name.Anonymous ],
+        Constrexpr.Default Glob_term.Explicit,
+        ty )
+  in
+  let arguments = List.map f args_type in
+  lambda_to_prod @@
+    List.fold_right
+      (fun arg body -> Constrexpr_ops.mkLambdaCN [ arg ] body)
+      arguments ret_type
+      
+
 (** Given a module application [F (A) (B) (C)] return [F] *)
 let rec extract_functor_name (name : Constrexpr.module_ast) =
   match name.v with

--- a/src/termutils.mli
+++ b/src/termutils.mli
@@ -96,6 +96,11 @@ val mk_lambda_with_type :
   Constrexpr.constr_expr ->
   Constrexpr.constr_expr
 
+val mk_arrow_ty :
+  args_type:Constrexpr.constr_expr list ->
+  ret_type:Constrexpr.constr_expr ->
+  Constrexpr.constr_expr
+
 (* fun (x : ...) -> forall (x : ...) *)
 val lambda_to_prod : Constrexpr.constr_expr -> Constrexpr.constr_expr
 val extract_functor_name : Constrexpr.module_ast -> CompiledModuleType.t

--- a/src/types.ml
+++ b/src/types.ml
@@ -631,6 +631,8 @@ end = struct
         }
     | ComputationalAxiom
         { default_ctx_params; compiled_context; compiled_signature; _ }
+    | RecordConstrAxiom
+        { default_ctx_params; compiled_context; compiled_signature; _ }
     | InductiveAxiom
         { default_ctx_params; compiled_context; compiled_signature; _ }
     | RecursiveAxiom
@@ -734,6 +736,9 @@ end = struct
     | OpaqueFieldDefinition definition ->
         let default_ctx_params = path_subst_ctx definition.default_ctx_params in
         OpaqueFieldDefinition { definition with default_ctx_params }
+    | RecordConstrAxiom r ->
+        let default_ctx_params = path_subst_ctx r.default_ctx_params in
+        RecordConstrAxiom { r with default_ctx_params }
     | ComputationalAxiom comp ->
         let axiom = Naming.replace_qualid_root ~source ~target comp.axiom in
         let default_ctx_params = path_subst_ctx comp.default_ctx_params in

--- a/src/types.ml
+++ b/src/types.ml
@@ -350,6 +350,14 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+
+    | RecordDefinition of {
+        rd : RecordDecl.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
+    
     | FamilyDefinition of {
         linkage : Linkage.t;
         compiled_context : CompiledModuleType.t;
@@ -470,6 +478,14 @@ end = struct
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+
+    | RecordDefinition of {
+        rd : RecordDecl.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
+  
     | FamilyDefinition of {
         linkage : Linkage.t;
         compiled_context : CompiledModuleType.t;
@@ -598,6 +614,7 @@ end = struct
         { default_ctx_params; compiled_context; compiled_signature; _ }
     | RecursorDefinition
         { default_ctx_params; compiled_context; compiled_signature; _ }
+    | RecordDefinition { default_ctx_params; compiled_context; compiled_signature; _ } 
     | TraitDefinition
         { default_ctx_params; compiled_context; compiled_signature; _ } ->
         { default_ctx_params; compiled_context; compiled_signature }
@@ -736,6 +753,16 @@ end = struct
               VernacInductive.path_subtitution definition.inductive ~source
                 ~target;
           }
+    | RecordDefinition record ->
+       let default_ctx_params = path_subst_ctx record.default_ctx_params in
+       let RecordDecl.{ name; ty; fields } = record.rd in
+       let rd =
+         let subst = Naming.replace_qualid_root ~ source ~target in
+         let ty = subst ty in
+         let fields = fields |> List.map (fun (name, ty) -> (name, subst ty)) in
+         RecordDecl.{ name; ty; fields }
+       in 
+       RecordDefinition { record with rd; default_ctx_params } 
     | FieldDefinition field ->
         let default_ctx_params = path_subst_ctx field.default_ctx_params in
         FieldDefinition { field with default_ctx_params }

--- a/src/types.ml
+++ b/src/types.ml
@@ -340,6 +340,20 @@ module Recursors = struct
   type t = Recursor.t RecursorStore.t
 end
 
+
+module RecordCompAxiomKind = struct
+  (* There are kinds of record compuational axiom *)
+  (* 1. Record constructor equality -- e.g Axiom X : forall i, (Build_lambda_arg_STLC i) = (Build_lambda_arg_SystemF i ty_unit). *)
+  (* 2. Record field computation -- e.g Axiom Y : forall i t, arg_ty (Build_lambda_arg_SystemF i t) = t. *)
+  type t =
+    | RecordConstrEq 
+    | RecordFieldComp of {
+        record_name: Names.Id.t;
+        constructor_name: Names.Id.t;
+        fields: Names.Id.t list; (* The field name this paticular constructor takes in *)
+      }
+end 
+
 (* Linkages *)
 
 (** A [LinkageElem] represents all information there is to know about afield
@@ -399,10 +413,8 @@ module rec LinkageElem : sig
 
     (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)    
     | RecordComputationalAxiom of {
-        name : Names.Id.t;        
-        record_name : Names.Id.t;        
-        constructor_name: Names.Id.t; (* The constructor_name involved with this computation behaviour *)
-        fields: Names.Id.t list; (* The field name this paticular constructor takes in *)
+        name: Names.Id.t;        
+        kind: RecordCompAxiomKind.t;                
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
@@ -562,9 +574,7 @@ end = struct
 
     | RecordComputationalAxiom of {
         name : Names.Id.t;
-        record_name : Names.Id.t;
-        constructor_name: Names.Id.t;
-        fields: Names.Id.t list;
+        kind: RecordCompAxiomKind.t;        
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;

--- a/src/types.ml
+++ b/src/types.ml
@@ -367,6 +367,13 @@ module rec LinkageElem : sig
     | RecordDefinition of {
         rd : RecordDecl.t;
         original : VernacInductive.t;
+        (* The field names which have default values *)
+        (* This means these fields were not in the original record *)
+        (* i.e, they were added into this linkage via record extension *)
+        (* This is a mapping from the name of the field
+           to the *actual* definition binding name of the
+           default value *)
+        defaults : (Names.Id.t * Libnames.qualid) list;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -525,6 +532,7 @@ end = struct
     | RecordDefinition of {
         rd : RecordDecl.t;
         original : VernacInductive.t;
+        defaults : (Names.Id.t * Libnames.qualid) list;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.ml
+++ b/src/types.ml
@@ -370,6 +370,7 @@ module rec LinkageElem : sig
      }
   
     (* e.g Axiom id : lambda_arg ->  ident. *)
+    (* We will reuse InductiveAxiom *)
     (* | RecordField { ... } *)
 
     (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)

--- a/src/types.ml
+++ b/src/types.ml
@@ -540,7 +540,7 @@ end = struct
         name : Names.Id.t;
         record_name : Names.Id.t; 
         fields : Names.Id.t list;
-        defaults : Libnames.qualid list; 
+        defaults : Libnames.qualid list;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.ml
+++ b/src/types.ml
@@ -399,7 +399,10 @@ module rec LinkageElem : sig
 
     (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)    
     | RecordComputationalAxiom of {
-        name : Names.Id.t;
+        name : Names.Id.t;        
+        record_name : Names.Id.t;        
+        constructor_name: Names.Id.t; (* The constructor_name involved with this computation behaviour *)
+        fields: Names.Id.t list; (* The field name this paticular constructor takes in *)
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
@@ -559,6 +562,9 @@ end = struct
 
     | RecordComputationalAxiom of {
         name : Names.Id.t;
+        record_name : Names.Id.t;
+        constructor_name: Names.Id.t;
+        fields: Names.Id.t list;
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;

--- a/src/types.ml
+++ b/src/types.ml
@@ -397,9 +397,14 @@ module rec LinkageElem : sig
     (* We will reuse InductiveAxiom *)
     (* | RecordField { ... } *)
 
-    (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)
-    (* Can we reuse `ComputationalAxiom` here? *)
-    (* | RecordConstrAxiom { ... } *)
+    (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)    
+    | RecordComputationalAxiom of {
+        name : Names.Id.t;
+        axiom : Constrexpr.constr_expr;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
     
     | FamilyDefinition of {
         linkage : Linkage.t;
@@ -550,6 +555,14 @@ end = struct
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
+
+    | RecordComputationalAxiom of {
+        name : Names.Id.t;
+        axiom : Constrexpr.constr_expr;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       } 
   
     | FamilyDefinition of {
@@ -659,6 +672,8 @@ end = struct
           compiled_impl = compiled_signature;
           _;
         }
+    | RecordComputationalAxiom
+        { default_ctx_params; compiled_context; compiled_signature; _ }
     | ComputationalAxiom
         { default_ctx_params; compiled_context; compiled_signature; _ }
     | RecordConstrAxiom
@@ -773,6 +788,10 @@ end = struct
         let axiom = Naming.replace_qualid_root ~source ~target comp.axiom in
         let default_ctx_params = path_subst_ctx comp.default_ctx_params in
         ComputationalAxiom { comp with axiom; default_ctx_params }
+    | RecordComputationalAxiom comp ->
+        let axiom = Naming.replace_qualid_root ~source ~target comp.axiom in
+        let default_ctx_params = path_subst_ctx comp.default_ctx_params in
+        RecordComputationalAxiom { comp with axiom; default_ctx_params }
     | FamilyDefinition family ->
         let context = family.linkage.context |> Bwd.map g in
         let linkage =

--- a/src/types.ml
+++ b/src/types.ml
@@ -357,6 +357,17 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+     (* e.g Axiom Build_lambda_arg_STLC : ident -> lambda_arg. *)
+    | RecordConstrAxiom of {        
+        name : Names.Id.t;
+        record_name : Names.Id.t; 
+        fields : Names.Id.t list; (* The fields implemented in this constructor *)
+        (* TODO: This RecordConstrAxiom also needs the default values
+           This can be computed during inheritance *)
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
     
     | FamilyDefinition of {
         linkage : Linkage.t;
@@ -495,6 +506,14 @@ end = struct
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    | RecordConstrAxiom of {        
+        name : Names.Id.t;
+        record_name : Names.Id.t; 
+        fields : Names.Id.t list;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      } 
   
     | FamilyDefinition of {
         linkage : Linkage.t;

--- a/src/types.ml
+++ b/src/types.ml
@@ -176,7 +176,13 @@ module VernacInductive = struct
               (remove_duplicates
                  (fun (_, ((n : Names.lident), _)) -> n.v)
                  (base_constr @ derived_constr))
-        | _, _ -> Errors.fail ~info:"Record types are not yet supported"
+        | ( Vernacexpr.RecordDecl (_base_sort, base_fields, _base_modifier),
+            Vernacexpr.RecordDecl (derived_sort, derived_fields, derived_modifier) ) ->
+            (* TODO: We are assuming there are not duplicates here -- a bold assumption *)
+            (* We will modify this when doing linkage concatenation *)
+            let combined_fields = base_fields @ derived_fields in
+            Vernacexpr.RecordDecl (derived_sort, combined_fields, derived_modifier)
+        | _, _ -> Errors.fail ~info:"Mismatched inductive and record types in concatenation"
       in
       let child_ind = (a, b, c, childcstrs) in
       (child_ind, [])

--- a/src/types.ml
+++ b/src/types.ml
@@ -20,7 +20,7 @@ module VernacInductive = struct
     match cstrlist with
     | Vernacexpr.Constructors cstrlist ->
         ((ind_type_name.v, ind_type), List.map each_constr cstrlist)
-    | Vernacexpr.RecordDecl _ -> Errors.fail ~info:"Records not yet supported"
+    | Vernacexpr.RecordDecl _ -> Errors.fail ~info:"Use FRecords for extensible records"
 
   (* name -> name list *)
   (* inductive name -> constructors *)
@@ -100,7 +100,7 @@ module VernacInductive = struct
               ind_type,
               csts ),
             decl_notations )
-      | _ -> Errors.fail ~info:"Records not yet supported"
+      | _ -> Errors.fail ~info:"Use FRecords for extensible records"
     in
     (* Exporting the names *)
     let alias_all_name_term_type_decl =
@@ -217,6 +217,46 @@ module VernacInductive = struct
     match result with
     | None -> Errors.fail ~info:"constructor not bound in any inductive"
     | Some result -> result
+end
+
+module RecordDecl = struct 
+  type t = {
+      name : Names.Id.t;
+      ty: Constrexpr.constr_expr;
+      fields : (Names.Id.t * Constrexpr.constr_expr) list
+  }
+
+  let parse (inductive: VernacInductive.t) =
+    let inductive_expr = inductive |> List.hd |> fst in
+    let ( (_, (ind_type_name, _)),
+          _ind_params,
+          ind_type,
+          ind_body ) =
+      inductive_expr 
+    in
+    let name = ind_type_name.v in     
+    let ty =
+      match ind_type with
+      | None -> Errors.fail ~info:"You need to provide the type for an FRecord"
+      | Some ty -> ty         
+    in
+    let fields = 
+      match ind_body with
+      | Vernacexpr.Constructors _ -> Errors.fail ~info:"Use FInductive for extensible inductive types"
+      | Vernacexpr.RecordDecl (_, fields, _) ->       
+         fields
+         |> List.map (fun (decl, _) ->
+            match decl with
+            | Vernacexpr.AssumExpr (name, _binder, ty) ->
+               let field_name =
+                 match name.v with
+                 | Names.Name.Anonymous -> Errors.fail ~info:"Expected Name.Name in FRecord field name but got Name.Anonymous"
+                 | Names.Name.Name id -> id 
+               in
+               field_name, ty 
+            | DefExpr _ -> Errors.fail ~info:"Expected AssumeExpr in FRecord field binding but got DefExpr")
+    in
+    { name; ty; fields; }
 end
 
 (* Module naming *)

--- a/src/types.ml
+++ b/src/types.ml
@@ -374,6 +374,7 @@ module rec LinkageElem : sig
            to the *actual* definition binding name of the
            default value *)
         defaults : (Names.Id.t * Libnames.qualid) list;
+        constructor_name : Names.Id.t; (* The *main* constructor for this record type *)
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -381,9 +382,12 @@ module rec LinkageElem : sig
      (* e.g Axiom Build_lambda_arg_STLC : ident -> lambda_arg. *)
     | RecordConstrAxiom of {        
         name : Names.Id.t;
-        record_name : Names.Id.t;
+        record_name : Names.Id.t; (* The name of the record we want to construct *)
         fields : Names.Id.t list; (* The fields implemented in this constructor *)
         defaults : Libnames.qualid list;  (* The default value names given above *)
+        (* The record constructor that takes in all the arguments. If this record hasn't been extended,
+           then it is None *)
+        main_constr_name : Names.Id.t option; 
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -532,6 +536,7 @@ end = struct
         rd : RecordDecl.t;
         original : VernacInductive.t;
         defaults : (Names.Id.t * Libnames.qualid) list;
+        constructor_name : Names.Id.t;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -541,6 +546,7 @@ end = struct
         record_name : Names.Id.t; 
         fields : Names.Id.t list;
         defaults : Libnames.qualid list;
+        main_constr_name : Names.Id.t option;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.ml
+++ b/src/types.ml
@@ -455,6 +455,16 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    (* This is just a dummy linkage element to demarcate things --
+       it simplifies inheritance of grouped inductives.
+       Because of the compilied context, it can add to proof compilation time
+       *)
+    | Marker of {
+        name : Names.Id.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
 
   type compiled_sig = {
     default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -572,6 +582,12 @@ end = struct
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    | Marker of {
+        name : Names.Id.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;        
+    }
 
   type compiled_sig = {
     default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -614,7 +630,8 @@ end = struct
         { default_ctx_params; compiled_context; compiled_signature; _ }
     | RecursorDefinition
         { default_ctx_params; compiled_context; compiled_signature; _ }
-    | RecordDefinition { default_ctx_params; compiled_context; compiled_signature; _ } 
+    | RecordDefinition { default_ctx_params; compiled_context; compiled_signature; _ }
+    | Marker { default_ctx_params; compiled_context; compiled_signature; _ } 
     | TraitDefinition
         { default_ctx_params; compiled_context; compiled_signature; _ } ->
         { default_ctx_params; compiled_context; compiled_signature }
@@ -772,6 +789,9 @@ end = struct
     | TheoremDefinition definition ->
         let default_ctx_params = path_subst_ctx definition.default_ctx_params in
         TheoremDefinition { definition with default_ctx_params }
+    | Marker marker ->
+        let default_ctx_params = path_subst_ctx marker.default_ctx_params in
+        Marker { marker with default_ctx_params }
 
   and path_subtitution linkage ~source ~target =
     let f (name, elem) = (name, path_substitution_elem elem ~source ~target) in

--- a/src/types.ml
+++ b/src/types.ml
@@ -20,7 +20,7 @@ module VernacInductive = struct
     match cstrlist with
     | Vernacexpr.Constructors cstrlist ->
         ((ind_type_name.v, ind_type), List.map each_constr cstrlist)
-    | Vernacexpr.RecordDecl _ -> Errors.fail ~info:"Use FRecords for extensible records"
+    | Vernacexpr.RecordDecl _ -> ((ind_type_name.v, ind_type), [])
 
   (* name -> name list *)
   (* inductive name -> constructors *)
@@ -60,6 +60,7 @@ module VernacInductive = struct
     inductive |> extract_all_names |> List.map fst
 
   (* Create a "definition mapping" *)
+  (* Works for both Inductive and Record *)
   let definition_mapping ind_def =
     let all_names_with_type =
       let type_decls, constr_decls =
@@ -100,7 +101,13 @@ module VernacInductive = struct
               ind_type,
               csts ),
             decl_notations )
-      | _ -> Errors.fail ~info:"Use FRecords for extensible records"
+      (* Rename only the record type name *)
+      | Vernacexpr.RecordDecl _ ->
+         ( ( (coercion_flag, (ind_type_name, cumul_univ_decl)),
+              ind_params,
+              ind_type,
+              csts ),
+            decl_notations )
     in
     (* Exporting the names *)
     let alias_all_name_term_type_decl =

--- a/src/types.ml
+++ b/src/types.ml
@@ -234,7 +234,7 @@ module RecordDecl = struct
           ind_body ) =
       inductive_expr 
     in
-    let name = ind_type_name.v in     
+    let name = ind_type_name.v in
     let ty =
       match ind_type with
       | None -> Errors.fail ~info:"You need to provide the type for an FRecord"
@@ -353,6 +353,7 @@ module rec LinkageElem : sig
 
     | RecordDefinition of {
         rd : RecordDecl.t;
+        original : VernacInductive.t;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -510,6 +511,7 @@ end = struct
 
     | RecordDefinition of {
         rd : RecordDecl.t;
+        original : VernacInductive.t;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.ml
+++ b/src/types.ml
@@ -381,10 +381,9 @@ module rec LinkageElem : sig
      (* e.g Axiom Build_lambda_arg_STLC : ident -> lambda_arg. *)
     | RecordConstrAxiom of {        
         name : Names.Id.t;
-        record_name : Names.Id.t; 
+        record_name : Names.Id.t;
         fields : Names.Id.t list; (* The fields implemented in this constructor *)
-        (* TODO: This RecordConstrAxiom also needs the default values
-           This can be computed during inheritance *)
+        defaults : Libnames.qualid list;  (* The default value names given above *)
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -541,6 +540,7 @@ end = struct
         name : Names.Id.t;
         record_name : Names.Id.t; 
         fields : Names.Id.t list;
+        defaults : Libnames.qualid list; 
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.ml
+++ b/src/types.ml
@@ -367,7 +367,14 @@ module rec LinkageElem : sig
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
-      }
+     }
+  
+    (* e.g Axiom id : lambda_arg ->  ident. *)
+    (* | RecordField { ... } *)
+
+    (* e.g Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x. *)
+    (* Can we reuse `ComputationalAxiom` here? *)
+    (* | RecordConstrAxiom { ... } *)
     
     | FamilyDefinition of {
         linkage : Linkage.t;

--- a/src/types.mli
+++ b/src/types.mli
@@ -113,6 +113,7 @@ module rec LinkageElem : sig
         rd : RecordDecl.t;
         original : VernacInductive.t;
         defaults : (Names.Id.t * Libnames.qualid) list;
+        constructor_name : Names.Id.t;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
@@ -122,6 +123,7 @@ module rec LinkageElem : sig
         record_name : Names.Id.t; 
         fields : Names.Id.t list;
         defaults : Libnames.qualid list;
+        main_constr_name : Names.Id.t option;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.mli
+++ b/src/types.mli
@@ -112,6 +112,7 @@ module rec LinkageElem : sig
     | RecordDefinition of {
         rd : RecordDecl.t;
         original : VernacInductive.t;
+        defaults : (Names.Id.t * Libnames.qualid) list;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.mli
+++ b/src/types.mli
@@ -201,6 +201,12 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    | Marker of {
+        name : Names.Id.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
 
   type compiled_sig = {
     default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.mli
+++ b/src/types.mli
@@ -127,7 +127,14 @@ module rec LinkageElem : sig
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
-      } 
+      }
+    | RecordComputationalAxiom of {
+        name : Names.Id.t;
+        axiom : Constrexpr.constr_expr;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
     | FamilyDefinition of {
         linkage : Linkage.t;
         compiled_context : CompiledModuleType.t;

--- a/src/types.mli
+++ b/src/types.mli
@@ -121,6 +121,7 @@ module rec LinkageElem : sig
         name : Names.Id.t;
         record_name : Names.Id.t; 
         fields : Names.Id.t list;
+        defaults : Libnames.qualid list;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.mli
+++ b/src/types.mli
@@ -111,6 +111,7 @@ module rec LinkageElem : sig
       }
     | RecordDefinition of {
         rd : RecordDecl.t;
+        original : VernacInductive.t;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;

--- a/src/types.mli
+++ b/src/types.mli
@@ -115,6 +115,14 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    | RecordConstrAxiom of {        
+        name : Names.Id.t;
+        record_name : Names.Id.t; 
+        fields : Names.Id.t list;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      } 
     | FamilyDefinition of {
         linkage : Linkage.t;
         compiled_context : CompiledModuleType.t;

--- a/src/types.mli
+++ b/src/types.mli
@@ -109,6 +109,12 @@ module rec LinkageElem : sig
         compiled_signature : CompiledModuleType.t;
         default_ctx_params : (Names.Id.t * CompiledModule.t) list;
       }
+    | RecordDefinition of {
+        rd : RecordDecl.t;
+        compiled_context : CompiledModuleType.t;
+        compiled_signature : CompiledModuleType.t;
+        default_ctx_params : (Names.Id.t * CompiledModule.t) list;
+      }
     | FamilyDefinition of {
         linkage : Linkage.t;
         compiled_context : CompiledModuleType.t;

--- a/src/types.mli
+++ b/src/types.mli
@@ -34,6 +34,16 @@ module VernacInductive : sig
     constructor:Names.Id.t -> inductive:t -> Names.Id.t
 end
 
+module RecordDecl : sig
+  type t = {
+      name : Names.Id.t;
+      ty: Constrexpr.constr_expr;
+      fields : (Names.Id.t * Constrexpr.constr_expr) list
+  }
+  val parse : VernacInductive.t -> t
+ (* val extract_fields : t -> (Names.Id.t * Constrexpr.constr_expr) list*)
+end
+
 module CompiledModule : sig
   type t = Libnames.qualid
 end

--- a/src/types.mli
+++ b/src/types.mli
@@ -130,6 +130,9 @@ module rec LinkageElem : sig
       }
     | RecordComputationalAxiom of {
         name : Names.Id.t;
+        record_name : Names.Id.t;
+        constructor_name: Names.Id.t;
+        fields: Names.Id.t list;
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;

--- a/src/types.mli
+++ b/src/types.mli
@@ -94,6 +94,12 @@ module PluginCmdScope : sig
   }
 end
 
+module RecordCompAxiomKind : sig  
+  type t =
+    | RecordConstrEq 
+    | RecordFieldComp of { record_name: Names.Id.t; constructor_name: Names.Id.t; fields: Names.Id.t list; }
+end
+
 module rec LinkageElem : sig
   type t =
     | InductiveDefinition of {
@@ -130,9 +136,7 @@ module rec LinkageElem : sig
       }
     | RecordComputationalAxiom of {
         name : Names.Id.t;
-        record_name : Names.Id.t;
-        constructor_name: Names.Id.t;
-        fields: Names.Id.t list;
+        kind: RecordCompAxiomKind.t;        
         axiom : Constrexpr.constr_expr;
         compiled_context : CompiledModuleType.t;
         compiled_signature : CompiledModuleType.t;

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -49,6 +49,7 @@ FInductive ty: Set :=
 FRecord lambda_arg : Set := {
     arg_ty : ty;
 }.
+FDefault lambda_arg arg_ty = ty_unit.
 
 FInductive tm : Type :=  
 | tm_tabs : tvar -> tm -> tm  (* Λα.t *)

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -50,7 +50,7 @@ FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 FEnd S.
 
 (* FDefinition i := Source.Build_lambda_arg_S 10 Source.ty_unit.*)
-(* FDefinition j := {| Source.id := 10; Source.arg_ty := Source.ty_unit |}.*)
+FDefinition j := {| S.id := 10; S.arg_ty := S.ty_unit |}.
 
 FEnd Ext.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -49,8 +49,8 @@ Family S.
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 FEnd S.
 
-(* FDefinition i := Source.Build_lambda_arg_S 10 Source.ty_unit.*)
-FDefinition j := {| S.id := 10; S.arg_ty := S.ty_unit |}.
+FDefinition j : S.lambda_arg := {| S.id := 10; S.arg_ty := S.ty_unit |}.
+FDefinition k : ident := j.(S.id).
 
 FEnd Ext.
 
@@ -67,16 +67,17 @@ FRecord mt : Set := { }.
 
 FDefinition io : mt := {| |}.
 
-FDefinition x : lambda_arg := {| id := 10 |}. 
+FDefinition x : lambda_arg := {| id := 10 |}.
 FDefinition y : ident := id {| id := 10 |}.
+
 FDefinition llo := x.(id).
 
-(*
-FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.
+FDefinition hh := {| id := 10 |} = {| id := 10 |}.
+FDefinition qq := {| id := 10 |}.(id) = {| id := 10 |}.(id).
+(*FLemma easy_lemma : {| id := 10 |}.(id) = id {| id := 10 |}.
 FProofLemma.
 fsimpl.
-Qed. CloseFLemma.
-*)
+Qed. CloseFLemma.*)
 
 
 (*

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -42,11 +42,10 @@ FInductive tm : Type :=
 FEnd S.
 
 
-(*FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
+FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
 FProofLemma.
-intros. rewrite S.RecordCompAxiom回Records_test_19; reflexivity.
+intros. fsimpl. reflexivity.
 Qed. CloseFLemma.
-*)
 
 FEnd Base.
 
@@ -106,7 +105,6 @@ FInductive tm : Type :=
 
 FEnd STLC.
 
-
 Family SystemF extends STLC.
 
 FDefinition tvar := nat.
@@ -135,7 +133,7 @@ FEnd lambda_arg_constr_SystemF.
      FRecursion/FInduction *)
 MetaData lambda_arg_eq_STLC.
 Axiom axiom_id0 : forall i t, arg_ty (Build_lambda_arg_SystemF i t) = t.
-Axiom axiom_id1 : forall i, (Build_lambda_arg_STLC i) = (Build_lambda_arg_SystemF i ty_unit).
+Axiom axiom_id1 : forall i, (Build_lambda_arg_STLC i) = (Build_lambda_arg_SystemF i ty_unit).a
 FEnd lambda_arg_eq_STLC.
 
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -2,6 +2,13 @@ Require Import Rocqet.Loader.
 
 Definition ident := nat.
 
+Record lambda_arg : Set := {
+    id : ident;
+  }.
+
+Definition x := {| id := 0 |}.
+Definition y := Build_lambda_arg 0.
+
 Family STLC.
 FInductive ty: Set :=
   | ty_unit : ty
@@ -10,6 +17,18 @@ FInductive ty: Set :=
 FRecord lambda_arg : Set := {
     id : ident;
 }.
+
+MetaData _id_comp.
+Axiom id : lambda_arg ->  ident.
+FEnd _id_comp.
+
+MetaData lambda_arg_constr_STLC.
+Axiom Build_lambda_arg_STLC : ident -> lambda_arg.
+FEnd lambda_arg_constr_STLC.
+
+MetaData lambda_arg_eq_STLC.
+Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x.
+FEnd lambda_arg_eq_STLC.
 
 FInductive tm : Type :=
   | tm_var : ident -> tm    
@@ -21,7 +40,5 @@ FEnd STLC.
 
 
 Family SystemF extends STLC.
-
-
 
 FEnd SystemF.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -41,7 +41,6 @@ FInductive tm : Type :=
 
 FEnd S.
 
-
 FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10 -> True.
 FProofLemma.
 intros. fsimpl in H; reflexivity.
@@ -58,6 +57,16 @@ Family Ext extends Base.
 
 Family S.
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
+
+
+Family inner0.
+Family inner1.
+
+FDefinition vv : lambda_arg := {| id := 10; arg_ty := ty_unit |}.
+
+FEnd inner1.
+FEnd inner0.
+
 FEnd S.
 
 FDefinition j : S.lambda_arg := {| S.id := 10; S.arg_ty := S.ty_unit |}.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -44,7 +44,7 @@ FEnd S.
 
 FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10 -> True.
 FProofLemma.
-intros. fsimpl in H. fsimpl. reflexivity.
+intros. fsimpl in H; reflexivity.
 Qed. CloseFLemma.
 
 FEnd Base.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -20,13 +20,11 @@ FRecord lambda_arg : Set := {
 
 FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 
+FDefinition y : ident := id (Build_lambda_arg_STLC 10).
+
 (*MetaData _id_comp.
 Axiom id : lambda_arg ->  ident.
 FEnd _id_comp.
-
-MetaData lambda_arg_constr_STLC.
-Axiom Build_lambda_arg_STLC : ident -> lambda_arg.
-FEnd lambda_arg_constr_STLC.
 
 MetaData lambda_arg_eq_STLC.
 Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -1,0 +1,27 @@
+Require Import Rocqet.Loader.
+
+Definition ident := nat.
+
+Family STLC.
+FInductive ty: Set :=
+  | ty_unit : ty
+  | ty_arrow : ty -> ty -> ty.
+
+FRecord lambda_arg : Type := {
+    id : ident;
+}.
+
+FInductive tm : Set :=
+  | tm_var : ident -> tm    
+  | tm_abs : lambda_arg -> tm -> tm
+  | tm_app : tm -> tm -> tm
+  | tm_unit: tm.
+
+FEnd STLC.
+
+
+Family SystemF extends STLC.
+
+
+
+FEnd SystemF.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -62,6 +62,9 @@ FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
 FDefinition j := Build_lambda_arg_SystemF 10 ty_unit.
 
+FEnd SystemF.
+
+(*
 MetaData lambda_arg_constr_SystemF.
 Axiom Build_lambda_arg_SystemF : ident -> ty -> lambda_arg.
 FEnd lambda_arg_constr_SystemF.
@@ -89,3 +92,4 @@ Family SystemFOmega extends SystemF.
 FRecord B : Set := { } default arg_ty := ty_unit, argn := 10.
 
 FEnd SystemFOmega.
+*)

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -64,6 +64,11 @@ Family inner1.
 
 FDefinition vv : lambda_arg := {| id := 10; arg_ty := ty_unit |}.
 
+FLemma easy_lemma : {| id := 10; arg_ty := ty_unit |}.(id) = 10 -> True.
+FProofLemma.
+intros. fsimpl in H; reflexivity.
+Qed. CloseFLemma.
+
 FEnd inner1.
 FEnd inner0.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -23,6 +23,39 @@ Record lambda_arg : Set := Build_lambda_arg { id : ident }.
 Definition x := {| id := 0 |}.
 Definition y := x.(id).*)
 
+Family Base.
+
+Family S.
+
+FInductive ty: Set :=
+| ty_unit : ty
+| ty_arrow : ty -> ty -> ty.
+
+FRecord lambda_arg : Set := { id : ident }.
+
+FInductive tm : Type :=
+| tm_var : ident -> tm    
+| tm_abs : lambda_arg -> tm -> tm
+| tm_app : tm -> tm -> tm
+| tm_unit: tm.
+
+FEnd S.
+
+FEnd Base.
+
+Family Ext extends Base.
+
+Family S.
+FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
+FEnd S.
+
+(* FDefinition i := Source.Build_lambda_arg_S 10 Source.ty_unit.*)
+(* FDefinition j := {| Source.id := 10; Source.arg_ty := Source.ty_unit |}.*)
+
+FEnd Ext.
+
+(* Print CompilerExt.Source.*)
+
 Family STLC.
 
 FInductive ty: Set :=
@@ -69,8 +102,6 @@ FInductive ty: Set :=
 | ty_forall : tvar -> ty -> ty. (* ∀α.T *)
 
 (* tm_abs is extended with a type *)
-FRecord A : Set := { }.
-
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
 FDefinition kl : lambda_arg := {| id := 10; arg_ty := ty_unit; |}.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -2,12 +2,12 @@ Require Import Rocqet.Loader.
 
 Definition ident := nat.
 
-Record lambda_arg : Set := {
+(*Record lambda_arg : Set := {
     id : ident;
   }.
 
 Definition x := {| id := 0 |}.
-Definition y := Build_lambda_arg 0.
+Definition y := Build_lambda_arg 0.*)
 
 Family STLC.
 FInductive ty: Set :=

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -2,13 +2,14 @@ Require Import Rocqet.Loader.
 
 Definition ident := nat.
 
-(* Record lambda_arg : Set := Build_lambda_arg { id : ident }.*)
+Record lambda_arg : Set := Build_lambda_arg { id : ident }.
+Definition x := {| id := 0 |}.
 
 (*Record lambda_arg : Set := {
     id : ident;
   }.
 
-Definition x := {| id := 0 |}.
+
 Definition y := Build_lambda_arg 0.*)
 
 Family STLC.
@@ -19,6 +20,7 @@ FInductive ty: Set :=
 
 FRecord lambda_arg : Set := { id : ident }.
 
+FDefinition i := {| x := 10 |}.
 FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 FDefinition y : ident := id (Build_lambda_arg_STLC 10).
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -20,9 +20,8 @@ FInductive ty: Set :=
 
 FRecord lambda_arg : Set := { id : ident }.
 
-(* FDefinition i := {| x := 10 |}.*)
 FDefinition x : lambda_arg := {| id := 10 |}. 
-(* FDefinition y : ident := id {| id := 10 |}.*)
+FDefinition y : ident := id {| id := 10 |}.
 
 (*
 FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.
@@ -60,8 +59,7 @@ FRecord A : Set := { }.
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
 FDefinition kl : lambda_arg := {| id := 10; arg_ty := ty_unit; |}.
-
-FDefinition j := Build_lambda_arg_SystemF 10 ty_unit.
+FDefinition j : ty := arg_ty {| id := 10; arg_ty := ty_unit; |}.
 
 FEnd SystemF.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -42,10 +42,11 @@ FInductive tm : Type :=
 FEnd S.
 
 
-FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
+(*FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
 FProofLemma.
 intros. rewrite S.RecordCompAxiom回Records_test_19; reflexivity.
 Qed. CloseFLemma.
+*)
 
 FEnd Base.
 
@@ -65,7 +66,7 @@ FDefinition k : ident := j.(S.id).
 
 FEnd Ext.
 
-(* Print CompilerExt.Source.*)
+Print Ext.S.
 
 Family STLC.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -49,7 +49,7 @@ FInductive ty: Set :=
 FRecord lambda_arg : Set := {
     arg_ty : ty;
 }.
-FDefault lambda_arg arg_ty = ty_unit.
+FDefault lambda_arg arg_ty := ty_unit.
 
 FInductive tm : Type :=  
 | tm_tabs : tvar -> tm -> tm  (* Λα.t *)

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -1,16 +1,21 @@
 Require Import Rocqet.Loader.
 
+
 Definition ident := nat.
 
-(*Record lambda_arg : Set := Build_lambda_arg { id : ident }.
-Definition x := {| id := 0 |}.*)
+(*
 
-(*Record lambda_arg : Set := {
-    id : ident;
-  }.
+We also want to support records nested inside families.
+Module R.
+Record lambda_arg : Set := Build_lambda_arg { id : ident }.
+Definition x := {| id := 0 |}.
+End R.
 
+Definition lmo := {| R.id := 10 |}.
 
-Definition y := Build_lambda_arg 0.*)
+*)
+
+(*Definition y := Build_lambda_arg 0.*)
 
 Family STLC.
 
@@ -19,6 +24,9 @@ FInductive ty: Set :=
 | ty_arrow : ty -> ty -> ty.
 
 FRecord lambda_arg : Set := { id : ident }.
+FRecord mt : Set := { }.
+
+FDefinition io : mt := {| |}.
 
 FDefinition x : lambda_arg := {| id := 10 |}. 
 FDefinition y : ident := id {| id := 10 |}.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -2,6 +2,8 @@ Require Import Rocqet.Loader.
 
 Definition ident := nat.
 
+(* Record lambda_arg : Set := Build_lambda_arg { id : ident }.*)
+
 (*Record lambda_arg : Set := {
     id : ident;
   }.
@@ -21,6 +23,8 @@ FRecord lambda_arg : Set := {
 FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 
 FDefinition y : ident := id (Build_lambda_arg_STLC 10).
+
+FEnd STLC.
 
 (*MetaData _id_comp.
 Axiom id : lambda_arg ->  ident.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -7,11 +7,11 @@ FInductive ty: Set :=
   | ty_unit : ty
   | ty_arrow : ty -> ty -> ty.
 
-FRecord lambda_arg : Type := {
+FRecord lambda_arg : Set := {
     id : ident;
 }.
 
-FInductive tm : Set :=
+FInductive tm : Type :=
   | tm_var : ident -> tm    
   | tm_abs : lambda_arg -> tm -> tm
   | tm_app : tm -> tm -> tm

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -41,6 +41,7 @@ FInductive tm : Type :=
 
 FEnd S.
 
+
 FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
 FProofLemma.
 intros. rewrite S.RecordCompAxiom回Records_test_19; reflexivity.
@@ -50,6 +51,8 @@ FEnd Base.
 
 Print Base.S.
 (* RecordCompAxiom回Records_test_19 *)
+(* RecordCompAxiom回RocqetTestsRecords_test_19 *)
+
 
 Family Ext extends Base.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -20,13 +20,14 @@ FInductive ty: Set :=
 FRecord lambda_arg : Set := { id : ident }.
 
 FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
-
 FDefinition y : ident := id (Build_lambda_arg_STLC 10).
 
+(*
 FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.
 FProofLemma.
 fsimpl.
 Qed. CloseFLemma.
+*)
 
 
 (*
@@ -52,7 +53,9 @@ FInductive ty: Set :=
 | ty_forall : tvar -> ty -> ty. (* ∀α.T *)
 
 (* tm_abs is extended with a type *)
-FRecord lambda_arg : Set := { arg_ty : ty } with default arg_ty := ty_unit.
+FRecord A : Set := { }.
+FRecord B : Set := { } default arg_ty := ty_unit | argn := 10.
+FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
 
 MetaData lambda_arg_constr_SystemF.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -54,7 +54,7 @@ FInductive ty: Set :=
 
 (* tm_abs is extended with a type *)
 FRecord A : Set := { }.
-FRecord B : Set := { } default arg_ty := ty_unit | argn := 10.
+FRecord B : Set := { } default arg_ty := ty_unit, argn := 10.
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -41,7 +41,15 @@ FInductive tm : Type :=
 
 FEnd S.
 
+FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
+FProofLemma.
+intros. rewrite S.RecordCompAxiom回Records_test_19; reflexivity.
+Qed. CloseFLemma.
+
 FEnd Base.
+
+Print Base.S.
+(* RecordCompAxiom回Records_test_19 *)
 
 Family Ext extends Base.
 
@@ -82,7 +90,7 @@ Qed. CloseFLemma.*)
 
 (*
 MetaData lambda_arg_eq_STLC.
-Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x.
+Axiom id_lambda_arg_eq : forall x, id (Build_lambda_arg_STLC x) = x.
 FEnd lambda_arg_eq_STLC.
 *)
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -16,9 +16,7 @@ FInductive ty: Set :=
   | ty_unit : ty
   | ty_arrow : ty -> ty -> ty.
 
-FRecord lambda_arg : Set := {
-    id : ident;
-  }.
+FRecord lambda_arg : Set := { id : ident }.
 
 FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -12,9 +12,10 @@ Definition x := {| id := 0 |}.
 Definition y := Build_lambda_arg 0.*)
 
 Family STLC.
+
 FInductive ty: Set :=
-  | ty_unit : ty
-  | ty_arrow : ty -> ty -> ty.
+| ty_unit : ty
+| ty_arrow : ty -> ty -> ty.
 
 FRecord lambda_arg : Set := { id : ident }.
 
@@ -22,45 +23,52 @@ FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 
 FDefinition y : ident := id (Build_lambda_arg_STLC 10).
 
-FEnd STLC.
+FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.
+FProofLemma.
+fsimpl.
+Qed. CloseFLemma.
 
-(*MetaData _id_comp.
-Axiom id : lambda_arg ->  ident.
-FEnd _id_comp.
 
+(*
 MetaData lambda_arg_eq_STLC.
 Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x.
-FEnd lambda_arg_eq_STLC.*)
+FEnd lambda_arg_eq_STLC.
+*)
 
 FInductive tm : Type :=
-  | tm_var : ident -> tm    
-  | tm_abs : lambda_arg -> tm -> tm
-  | tm_app : tm -> tm -> tm
-  | tm_unit: tm.
+| tm_var : ident -> tm    
+| tm_abs : lambda_arg -> tm -> tm
+| tm_app : tm -> tm -> tm
+| tm_unit: tm.
 
 FEnd STLC.
 
 
-Family SystemF extends STLC. 
+Family SystemF extends STLC.
+
 FDefinition tvar := nat.
 
 FInductive ty: Set :=
 | ty_forall : tvar -> ty -> ty. (* ∀α.T *)
 
 (* tm_abs is extended with a type *)
-FRecord lambda_arg : Set := {
-    arg_ty : ty;
-  }.
-FDefault lambda_arg arg_ty := ty_unit.
+FRecord lambda_arg : Set := { arg_ty : ty } with default arg_ty := ty_unit.
+
 
 MetaData lambda_arg_constr_SystemF.
 Axiom Build_lambda_arg_SystemF : ident -> ty -> lambda_arg.
 FEnd lambda_arg_constr_SystemF.
 
+(* Is it possible to modularly compose two records? We need a way to supply the
+   default value. A couple of options:
+   - Allow field to have default values regardless of whether we're extending
+     a field or not
+   - Allow to supply the default value like a proof obligation -- similar to
+     FRecursion/FInduction *)
 MetaData lambda_arg_eq_STLC.
 Axiom axiom_id0 : forall i t, arg_ty (Build_lambda_arg_SystemF i t) = t.
 Axiom axiom_id1 : forall i, (Build_lambda_arg_STLC i) = (Build_lambda_arg_SystemF i ty_unit).
-FEnd lambda_arg_eq_STLC.*)
+FEnd lambda_arg_eq_STLC.
 
 
 FInductive tm : Type :=  

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -54,11 +54,13 @@ FInductive ty: Set :=
 
 (* tm_abs is extended with a type *)
 FRecord A : Set := { }.
-FRecord B : Set := { } default arg_ty := ty_unit, argn := 10.
+
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
+
 (* How do we implement the inherited constructors? *)
 (* Ding! Ding! Ding! With default values! *)
 
+FDefinition j := Build_lambda_arg_SystemF 10 ty_unit.
 
 MetaData lambda_arg_constr_SystemF.
 Axiom Build_lambda_arg_SystemF : ident -> ty -> lambda_arg.
@@ -83,5 +85,7 @@ FInductive tm : Type :=
 FEnd SystemF.
 
 Family SystemFOmega extends SystemF.
+
+FRecord B : Set := { } default arg_ty := ty_unit, argn := 10.
 
 FEnd SystemFOmega.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -36,6 +36,7 @@ FDefinition io : mt := {| |}.
 
 FDefinition x : lambda_arg := {| id := 10 |}. 
 FDefinition y : ident := id {| id := 10 |}.
+FDefinition llo := y.(id).
 
 (*
 FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -42,9 +42,9 @@ FInductive tm : Type :=
 FEnd S.
 
 
-FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10.
+FLemma easy_lemma : {| S.id := 10 |}.(S.id) = 10 -> True.
 FProofLemma.
-intros. fsimpl. reflexivity.
+intros. fsimpl in H. fsimpl. reflexivity.
 Qed. CloseFLemma.
 
 FEnd Base.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -18,7 +18,7 @@ FRecord lambda_arg : Set := {
     id : ident;
 }.
 
-MetaData _id_comp.
+(*MetaData _id_comp.
 Axiom id : lambda_arg ->  ident.
 FEnd _id_comp.
 
@@ -28,7 +28,7 @@ FEnd lambda_arg_constr_STLC.
 
 MetaData lambda_arg_eq_STLC.
 Axiom axiom_id : forall x, id (Build_lambda_arg_STLC x) = x.
-FEnd lambda_arg_eq_STLC.
+FEnd lambda_arg_eq_STLC.*)
 
 FInductive tm : Type :=
   | tm_var : ident -> tm    
@@ -48,8 +48,18 @@ FInductive ty: Set :=
 (* tm_abs is extended with a type *)
 FRecord lambda_arg : Set := {
     arg_ty : ty;
-}.
+  }.
 FDefault lambda_arg arg_ty := ty_unit.
+
+MetaData lambda_arg_constr_SystemF.
+Axiom Build_lambda_arg_SystemF : ident -> ty -> lambda_arg.
+FEnd lambda_arg_constr_SystemF.
+
+MetaData lambda_arg_eq_STLC.
+Axiom axiom_id0 : forall i t, arg_ty (Build_lambda_arg_SystemF i t) = t.
+Axiom axiom_id1 : forall i, (Build_lambda_arg_STLC i) = (Build_lambda_arg_SystemF i ty_unit).
+FEnd lambda_arg_eq_STLC.*)
+
 
 FInductive tm : Type :=  
 | tm_tabs : tvar -> tm -> tm  (* Λα.t *)

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -69,6 +69,16 @@ FEnd inner0.
 
 FEnd S.
 
+Family inner2.
+
+Family inner4.
+
+FDefinition gg : S.lambda_arg := {| S.id := 10; S.arg_ty := S.ty_unit |}.
+
+FEnd inner4.
+
+FEnd inner2.
+  
 FDefinition j : S.lambda_arg := {| S.id := 10; S.arg_ty := S.ty_unit |}.
 FDefinition k : ident := j.(S.id).
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -36,7 +36,7 @@ FDefinition io : mt := {| |}.
 
 FDefinition x : lambda_arg := {| id := 10 |}. 
 FDefinition y : ident := id {| id := 10 |}.
-FDefinition llo := y.(id).
+FDefinition llo := x.(id).
 
 (*
 FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -2,8 +2,8 @@ Require Import Rocqet.Loader.
 
 Definition ident := nat.
 
-Record lambda_arg : Set := Build_lambda_arg { id : ident }.
-Definition x := {| id := 0 |}.
+(*Record lambda_arg : Set := Build_lambda_arg { id : ident }.
+Definition x := {| id := 0 |}.*)
 
 (*Record lambda_arg : Set := {
     id : ident;
@@ -20,9 +20,9 @@ FInductive ty: Set :=
 
 FRecord lambda_arg : Set := { id : ident }.
 
-FDefinition i := {| x := 10 |}.
-FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
-FDefinition y : ident := id (Build_lambda_arg_STLC 10).
+(* FDefinition i := {| x := 10 |}.*)
+FDefinition x : lambda_arg := {| id := 10 |}. 
+(* FDefinition y : ident := id {| id := 10 |}.*)
 
 (*
 FLemma easy_lemma : id (Build_lambda_arg_STLC 10) = 10.
@@ -59,8 +59,7 @@ FRecord A : Set := { }.
 
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
 
-(* How do we implement the inherited constructors? *)
-(* Ding! Ding! Ding! With default values! *)
+FDefinition kl : lambda_arg := {| id := 10; arg_ty := ty_unit; |}.
 
 FDefinition j := Build_lambda_arg_SystemF 10 ty_unit.
 

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -56,6 +56,8 @@ FInductive ty: Set :=
 FRecord A : Set := { }.
 FRecord B : Set := { } default arg_ty := ty_unit, argn := 10.
 FRecord lambda_arg : Set := { arg_ty : ty } default arg_ty := ty_unit.
+(* How do we implement the inherited constructors? *)
+(* Ding! Ding! Ding! With default values! *)
 
 
 MetaData lambda_arg_constr_SystemF.
@@ -79,3 +81,7 @@ FInductive tm : Type :=
 | tm_tapp : tm -> ty -> tm.   (* t [T] *)
 
 FEnd SystemF.
+
+Family SystemFOmega extends SystemF.
+
+FEnd SystemFOmega.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -17,6 +17,12 @@ Definition lmo := {| R.id := 10 |}.
 
 (*Definition y := Build_lambda_arg 0.*)
 
+(*
+We also want to support record projection
+Record lambda_arg : Set := Build_lambda_arg { id : ident }.
+Definition x := {| id := 0 |}.
+Definition y := x.(id).*)
+
 Family STLC.
 
 FInductive ty: Set :=

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -16,7 +16,9 @@ FInductive ty: Set :=
 
 FRecord lambda_arg : Set := {
     id : ident;
-}.
+  }.
+
+FDefinition x : lambda_arg := Build_lambda_arg_STLC 10.
 
 (*MetaData _id_comp.
 Axiom id : lambda_arg ->  ident.

--- a/tests/Records_test.v
+++ b/tests/Records_test.v
@@ -39,6 +39,19 @@ FInductive tm : Type :=
 FEnd STLC.
 
 
-Family SystemF extends STLC.
+Family SystemF extends STLC. 
+FDefinition tvar := nat.
+
+FInductive ty: Set :=
+| ty_forall : tvar -> ty -> ty. (* ∀α.T *)
+
+(* tm_abs is extended with a type *)
+FRecord lambda_arg : Set := {
+    arg_ty : ty;
+}.
+
+FInductive tm : Type :=  
+| tm_tabs : tvar -> tm -> tm  (* Λα.t *)
+| tm_tapp : tm -> ty -> tm.   (* t [T] *)
 
 FEnd SystemF.

--- a/tests/dune
+++ b/tests/dune
@@ -52,4 +52,5 @@
   ;STLC_all
   ;STLC_horizon
   ;STLC_horizontal
+  Records_test 
   ))


### PR DESCRIPTION
This change adds `FRecord <name> : Type := { ... }`, which affords extensible records in `Rocqet`; it utiliizes a *similar* inheritance mechanism as `FInducitve`, but with a *novel* [compilation strategy](https://gist.github.com/ebresafegaga/78811488b167ba46a2e910ecaa784c25)